### PR TITLE
[codex] Make Quest refresh rate build-configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ runtime registration workflows.
 **Current state:** Metal/core runtime, Vulkan interop, controller and hand input paths, loader-backed
 runtime tests, `XR_EXT_conformance_automation`, `XR_EXT_hand_interaction`, and `XR_EXT_debug_utils`
 are in place. The Quest/Android client now feeds real `XR_EXT_hand_tracking` joints into the runtime
-matches per-frame render poses for headset compositor reprojection, and enables a first-pass dynamic
-`XR_FB_foveation` path when the headset supports it. The visionOS
+matches per-frame render poses for headset compositor reprojection, enables a first-pass dynamic
+`XR_FB_foveation` path when the headset supports it, and can request a build-configured display
+refresh rate. The visionOS
 viewer now starts from a minimal floating search window, enters immersive VR automatically when the
 stream connects, and sends head pose, hand joints, and first-pass tracked accessory controller data
 while the immersive space is open. The macOS SwiftUI apps now produce sandboxed App Store/TestFlight
@@ -46,6 +47,7 @@ Avoid duplicating the same guidance in multiple files. If commands, platform sta
 - `Session::EndFrame()` must stay non-blocking.
 - The streaming encoder queue is latest-frame-only.
 - Headset refresh rate is negotiated from the client.
+- The Quest Android client requests its preferred display refresh rate from the build-time `OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ` value.
 - Latency reports feed bounded pose prediction.
 - Headset clients must match `VIDEO_FLAG_RENDER_POSE` metadata to the decoded frame before projection submission.
 - Quest hand tracking depends on the Android manifest permission `com.oculus.permission.HAND_TRACKING` and the optional `oculus.software.handtracking` feature.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project utilizes AI-generated code and documentation. We appreciate your pr
 
 - Metal rendering, core runtime flow, Vulkan interop, and loader-backed runtime tests are in place.
 - `XR_EXT_conformance_automation`, `XR_EXT_hand_tracking`, `XR_EXT_hand_interaction`, and `XR_EXT_debug_utils` are implemented.
-- The Quest/Android client feeds real hand joints into the runtime, matches per-frame render poses for smoother headset reprojection, and exposes a first-pass `XR_FB_foveation` path when supported by the headset.
+- The Quest/Android client feeds real hand joints into the runtime, matches per-frame render poses for smoother headset reprojection, exposes a first-pass `XR_FB_foveation` path when supported by the headset, and can request a build-configured display refresh rate.
 - The visionOS viewer uses a minimal floating search window, then enters immersive VR automatically once the stream connects and sends head pose, hand joints, and first-pass tracked accessory controller data back to the runtime when available.
 - The macOS SwiftUI apps are configured for App Store/TestFlight packaging with sandboxed archives.
 - As of March 17, 2026, the pinned non-interactive OpenXR-CTS baseline is green locally: 63 passed, 36 skipped, 0 failed.

--- a/clients/android-openxr/app/build.gradle.kts
+++ b/clients/android-openxr/app/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     id("com.android.application")
 }
 
+val preferredDisplayRefreshRateHz =
+    providers.gradleProperty("openxrClientDisplayRefreshRateHz").orElse("72")
+
 android {
     namespace = "com.openxrosx.client"
     compileSdk = 35
@@ -27,7 +30,8 @@ android {
             cmake {
                 arguments += listOf(
                     "-DANDROID_STL=c++_shared",
-                    "-DANDROID_PLATFORM=android-29"
+                    "-DANDROID_PLATFORM=android-29",
+                    "-DOPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ=${preferredDisplayRefreshRateHz.get()}"
                 )
             }
         }

--- a/clients/android-openxr/app/src/main/cpp/CMakeLists.txt
+++ b/clients/android-openxr/app/src/main/cpp/CMakeLists.txt
@@ -6,6 +6,9 @@ project(OpenXROSXClient LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ "72" CACHE STRING
+    "Preferred headset display refresh rate requested by the Android client")
+
 # ─── OpenXR SDK (headers + loader) ──────────────────────────────────────────
 include(FetchContent)
 
@@ -64,4 +67,5 @@ target_link_libraries(openxr_osx_client PRIVATE
 target_compile_definitions(openxr_osx_client PRIVATE
     XR_USE_PLATFORM_ANDROID
     XR_USE_GRAPHICS_API_OPENGL_ES
+    OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ=${OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ}
 )

--- a/clients/android-openxr/app/src/main/cpp/XrApp.cpp
+++ b/clients/android-openxr/app/src/main/cpp/XrApp.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <jni.h>
 #include <netinet/in.h>
 #include <numeric>
 #include <sys/socket.h>
@@ -63,6 +62,14 @@ void main() {
 
 namespace oxr
 {
+
+namespace
+{
+
+constexpr float kPreferredDisplayRefreshRateHz =
+    static_cast<float>(OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ);
+
+} // namespace
 
 static int64_t SteadyClockNowNs()
 {
@@ -234,6 +241,8 @@ bool XrApp::Initialize(struct android_app* app)
 
 bool XrApp::CreateInstance(struct android_app* app)
 {
+    LOGI("Preferred display refresh rate target: %.1fHz", kPreferredDisplayRefreshRateHz);
+
     // Initialize the OpenXR loader on Android
     PFN_xrInitializeLoaderKHR initializeLoader = nullptr;
     xrGetInstanceProcAddr(XR_NULL_HANDLE, "xrInitializeLoaderKHR",
@@ -265,6 +274,7 @@ bool XrApp::CreateInstance(struct android_app* app)
     foveationAvailable_ = hasExtension(XR_FB_FOVEATION_EXTENSION_NAME);
     foveationConfigurationAvailable_ = hasExtension(XR_FB_FOVEATION_CONFIGURATION_EXTENSION_NAME);
     swapchainUpdateAvailable_ = hasExtension(XR_FB_SWAPCHAIN_UPDATE_STATE_EXTENSION_NAME);
+    displayRefreshRateAvailable_ = hasExtension(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME);
 
     std::vector<const char*> extensions = {
         XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME,
@@ -284,6 +294,10 @@ bool XrApp::CreateInstance(struct android_app* app)
     if (swapchainUpdateAvailable_)
     {
         extensions.push_back(XR_FB_SWAPCHAIN_UPDATE_STATE_EXTENSION_NAME);
+    }
+    if (displayRefreshRateAvailable_)
+    {
+        extensions.push_back(XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME);
     }
 
     XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
@@ -341,6 +355,24 @@ bool XrApp::CreateInstance(struct android_app* app)
              foveationAvailable_ ? 1 : 0,
              foveationConfigurationAvailable_ ? 1 : 0,
              swapchainUpdateAvailable_ ? 1 : 0);
+    }
+
+    if (displayRefreshRateAvailable_)
+    {
+        xrGetInstanceProcAddr(instance_, "xrEnumerateDisplayRefreshRatesFB",
+                              reinterpret_cast<PFN_xrVoidFunction*>(
+                                  &xrEnumerateDisplayRefreshRatesFB_));
+        xrGetInstanceProcAddr(instance_, "xrGetDisplayRefreshRateFB",
+                              reinterpret_cast<PFN_xrVoidFunction*>(
+                                  &xrGetDisplayRefreshRateFB_));
+        xrGetInstanceProcAddr(instance_, "xrRequestDisplayRefreshRateFB",
+                              reinterpret_cast<PFN_xrVoidFunction*>(
+                                  &xrRequestDisplayRefreshRateFB_));
+        LOGI("Display refresh rate support: ext=%d enum=%d get=%d request=%d",
+             displayRefreshRateAvailable_ ? 1 : 0,
+             xrEnumerateDisplayRefreshRatesFB_ != nullptr ? 1 : 0,
+             xrGetDisplayRefreshRateFB_ != nullptr ? 1 : 0,
+             xrRequestDisplayRefreshRateFB_ != nullptr ? 1 : 0);
     }
 
     // Query view configurations
@@ -511,6 +543,95 @@ bool XrApp::CreateSession()
     if (!InitializeHandTracking())
     {
         LOGW("Hand tracking unavailable on headset, continuing without it");
+    }
+
+    if (!InitializeDisplayRefreshRate())
+    {
+        LOGW("Display refresh rate control unavailable, continuing at runtime default");
+    }
+
+    return true;
+}
+
+bool XrApp::InitializeDisplayRefreshRate()
+{
+    if (!displayRefreshRateAvailable_ || session_ == XR_NULL_HANDLE)
+    {
+        return false;
+    }
+
+    if (!xrEnumerateDisplayRefreshRatesFB_ || !xrRequestDisplayRefreshRateFB_)
+    {
+        return false;
+    }
+
+    uint32_t rateCount = 0;
+    XrResult enumResult =
+        xrEnumerateDisplayRefreshRatesFB_(session_, 0, &rateCount, nullptr);
+    if (XR_FAILED(enumResult) || rateCount == 0)
+    {
+        LOGW("Failed to enumerate display refresh rates: %d (count=%u)",
+             enumResult, rateCount);
+        return false;
+    }
+
+    std::vector<float> refreshRates(rateCount, 0.0f);
+    enumResult = xrEnumerateDisplayRefreshRatesFB_(
+        session_, rateCount, &rateCount, refreshRates.data());
+    if (XR_FAILED(enumResult))
+    {
+        LOGW("Failed to fetch display refresh rates: %d", enumResult);
+        return false;
+    }
+
+    std::string supported;
+    for (uint32_t i = 0; i < rateCount; ++i)
+    {
+        if (!supported.empty())
+        {
+            supported += ", ";
+        }
+        supported += std::to_string(refreshRates[i]);
+    }
+    LOGI("Supported display refresh rates: [%s]", supported.c_str());
+
+    auto hasPreferredRate = std::any_of(refreshRates.begin(), refreshRates.end(),
+                                        [](float rate) {
+                                            return std::fabs(rate - kPreferredDisplayRefreshRateHz) < 0.5f;
+                                        });
+    if (!hasPreferredRate)
+    {
+        LOGW("Preferred %.1fHz not advertised by runtime, keeping current refresh rate",
+             kPreferredDisplayRefreshRateHz);
+        if (xrGetDisplayRefreshRateFB_ != nullptr)
+        {
+            float currentRate = 0.0f;
+            if (XR_SUCCEEDED(xrGetDisplayRefreshRateFB_(session_, &currentRate)))
+            {
+                LOGI("Current display refresh rate: %.1fHz", currentRate);
+            }
+        }
+        return true;
+    }
+
+    XrResult requestResult =
+        xrRequestDisplayRefreshRateFB_(session_, kPreferredDisplayRefreshRateHz);
+    if (XR_FAILED(requestResult))
+    {
+        LOGW("Failed to request %.1fHz display refresh rate: %d",
+             kPreferredDisplayRefreshRateHz, requestResult);
+        return false;
+    }
+
+    LOGI("Requested display refresh rate: %.1fHz", kPreferredDisplayRefreshRateHz);
+
+    if (xrGetDisplayRefreshRateFB_ != nullptr)
+    {
+        float currentRate = 0.0f;
+        if (XR_SUCCEEDED(xrGetDisplayRefreshRateFB_(session_, &currentRate)))
+        {
+            LOGI("Current display refresh rate after request: %.1fHz", currentRate);
+        }
     }
 
     return true;

--- a/clients/android-openxr/app/src/main/cpp/XrApp.h
+++ b/clients/android-openxr/app/src/main/cpp/XrApp.h
@@ -56,6 +56,7 @@ private:
     bool CreateSwapchains();
     bool InitializeHandTracking();
     bool InitializeFoveation();
+    bool InitializeDisplayRefreshRate();
     void ShutdownFoveation();
     void ShutdownHandTracking();
     void HandleSessionStateChange(XrSessionState newState);
@@ -97,9 +98,13 @@ private:
     bool foveationAvailable_ = false;
     bool foveationConfigurationAvailable_ = false;
     bool swapchainUpdateAvailable_ = false;
+    bool displayRefreshRateAvailable_ = false;
     PFN_xrCreateFoveationProfileFB xrCreateFoveationProfileFB_ = nullptr;
     PFN_xrDestroyFoveationProfileFB xrDestroyFoveationProfileFB_ = nullptr;
     PFN_xrUpdateSwapchainFB xrUpdateSwapchainFB_ = nullptr;
+    PFN_xrEnumerateDisplayRefreshRatesFB xrEnumerateDisplayRefreshRatesFB_ = nullptr;
+    PFN_xrGetDisplayRefreshRateFB xrGetDisplayRefreshRateFB_ = nullptr;
+    PFN_xrRequestDisplayRefreshRateFB xrRequestDisplayRefreshRateFB_ = nullptr;
     XrFoveationProfileFB foveationProfile_ = XR_NULL_HANDLE;
 
     // Controller actions

--- a/docs/platforms/quest.md
+++ b/docs/platforms/quest.md
@@ -32,12 +32,25 @@ Quest hand tracking requires the Android manifest to declare:
 
 If these entries are missing, the runtime can still operate, but headset-side hand joints will not be available.
 
+The Quest client's preferred display refresh request is build-configured. The default repository value
+is `72`, and you can override it per build with a Gradle property:
+
+```bash
+./gradlew assembleDebug -PopenxrClientDisplayRefreshRateHz=72
+```
+
+The property is passed through Gradle into CMake as
+`OPENXR_OSX_PREFERRED_DISPLAY_REFRESH_RATE_HZ`. Set it to a headset-supported rate such as `72`,
+`80`, `90`, or `120`. If the runtime does not advertise the requested rate, the client logs the
+mismatch and keeps the current headset refresh.
+
 ## Runtime Interaction
 
 The Quest client:
 
 - discovers the runtime on the local network
 - connects and advertises codec and refresh-rate preferences
+- requests the build-configured display refresh rate when `XR_FB_display_refresh_rate` is available
 - receives encoded video frames and matches render-pose metadata to each decoded frame before projection submission
 - sends head, controller, and optional hand-tracking data back to the runtime
 - reports latency measurements


### PR DESCRIPTION
@demonixis Really appreciate your work on this project!

I’ve recently gotten really into VR on macOS because I want to be able to play Elite Dangerous in VR on Mac. I know it’s a bit of a pipe dream since ED doesn’t run natively on macOS yet… but it actually runs through CrossOver on macOS pretty decently.

I have a somewhat “silly” plan to try building a proof-of-concept bridge so I can run ED in VR through CrossOver, with a proxy layer between CrossOver and macOS that passes VR data through to my Meta Quest 3 headset. 
I know it's not gonna be easy (I have [another note](https://blog.nicholas.clooney.io/notes/openxr-osx-crossover-bridge/#why-this-is-more-than-a-manifest-problem) explaining that to myself) but I want to try it out. 

## Summary
- make the Quest Android client's preferred display refresh rate build-configurable instead of hard-coded
- default that build-time value to 72Hz and allow per-build overrides with `-PopenxrClientDisplayRefreshRateHz=...`
- document the new override path in the Quest docs and project summaries

## Why
The client was forcing a fixed refresh-rate request in code. For this MVP path, a build-time knob is simpler than adding a runtime config surface while still letting developers target headset-supported rates when needed.

## Validation
- `mise exec java@temurin-17 -- ./gradlew assembleDebug`

## Notes
- the Android client still falls back to the headset's current refresh rate if `XR_FB_display_refresh_rate` is unavailable or the requested rate is not advertised
- CMake is the single source of truth for the default value, while Gradle only passes an optional override into the native build
