### PR TITLE
Fix streaming picture going backwards: encoder cross-queue reads of reused swapchain slots

### DIFF
--- a/runtime/src/EntryPoint.cpp
+++ b/runtime/src/EntryPoint.cpp
@@ -70,6 +70,14 @@ struct DebugUtilsMessengerState
 // Metal device — retained from xrGetMetalGraphicsRequirementsKHR
 static void* gMetalDevice = nullptr;
 
+// Unity's Metal command queue (from XrGraphicsBindingMetalKHR). The app renders
+// swapchain textures on it. The runtime encoder reads the same textures via a
+// blit on a separate queue, so it must synchronize the release->read against
+// this queue; otherwise the blit can read a stale slot before the app's render
+// completes (= picture going backwards). Non-static: accessed from Swapchain.mm
+// via extern.
+void* gUnityMetalCommandQueue = nullptr;
+
 // Suggested bindings storage: interactionProfile path -> list of (action handle, binding path string)
 struct SuggestedBinding
 {
@@ -865,6 +873,7 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrCreateSession(
     if (metalBinding)
     {
         gGraphicsApi = GraphicsApi::Metal;
+        gUnityMetalCommandQueue = metalBinding->commandQueue;
         gSession = std::make_unique<Session>(inst, gMetalDevice);
         *session = reinterpret_cast<XrSession>(gSession->GetHandle());
         spdlog::info("OXRSys: Session created with Metal binding");
@@ -887,6 +896,7 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrDestroySession(XrSession session)
     gActionSetsAttached = false;
     gAttachedActionSetHandles.clear();
     gSession.reset();
+    gUnityMetalCommandQueue = nullptr;
     return XR_SUCCESS;
 }
 

--- a/runtime/src/Session.cpp
+++ b/runtime/src/Session.cpp
@@ -465,6 +465,7 @@ XrResult Session::EndFrame(const XrFrameEndInfo* frameEndInfo)
     // Extract submitted eye textures for streaming
     void* leftTex = nullptr;
     void* rightTex = nullptr;
+    uint64_t snapshotValue = 0; // this frame's snapshot signal value, forwarded to the encoder for a GPU-side wait
 
     for (uint32_t i = 0; i < frameEndInfo->layerCount; i++)
     {
@@ -479,7 +480,8 @@ XrResult Session::EndFrame(const XrFrameEndInfo* frameEndInfo)
             case XR_TYPE_COMPOSITION_LAYER_PROJECTION:
             {
                 XrResult result = ValidateProjectionLayer(
-                    *reinterpret_cast<const XrCompositionLayerProjection*>(layer), leftTex, rightTex);
+                    *reinterpret_cast<const XrCompositionLayerProjection*>(layer), leftTex, rightTex,
+                    snapshotValue);
                 if (result != XR_SUCCESS)
                 {
                     Swapchain::ReleaseTextureSlice(leftTex);
@@ -511,7 +513,7 @@ XrResult Session::EndFrame(const XrFrameEndInfo* frameEndInfo)
     if (streamingServer_ && streamingServer_->IsClientConnected())
     {
         auto sendStart = Clock::now();
-        streamingServer_->SendFrame(leftTex, rightTex);
+        streamingServer_->SendFrame(leftTex, rightTex, snapshotValue);
         double enqueueMs = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
             Clock::now() - sendStart).count();
 
@@ -593,7 +595,8 @@ XrResult Session::ValidateSwapchainSubImage(const XrSwapchainSubImage& subImage)
 }
 
 XrResult Session::ValidateProjectionLayer(const XrCompositionLayerProjection& layer,
-                                          void*& leftTex, void*& rightTex) const
+                                          void*& leftTex, void*& rightTex,
+                                          uint64_t& snapshotValue) const
 {
     auto* space = Runtime::Get().FromHandle<Space>(reinterpret_cast<uint64_t>(layer.space));
     if (space == nullptr || space->GetSession() != this)
@@ -628,6 +631,9 @@ XrResult Session::ValidateProjectionLayer(const XrCompositionLayerProjection& la
         if (viewIndex == 0)
         {
             leftTex = textureSlice;
+            // Both eyes come from the same release of the same swapchain and share
+            // the same snapshot signal value, so read it once.
+            snapshotValue = swapchain->GetLastSnapshotValue();
         }
         else
         {

--- a/runtime/src/Session.h
+++ b/runtime/src/Session.h
@@ -111,7 +111,8 @@ private:
     bool OwnsSwapchain(const Swapchain* swapchain) const;
     XrResult ValidateSwapchainSubImage(const XrSwapchainSubImage& subImage) const;
     XrResult ValidateProjectionLayer(const XrCompositionLayerProjection& layer,
-                                     void*& leftTex, void*& rightTex) const;
+                                     void*& leftTex, void*& rightTex,
+                                     uint64_t& snapshotValue) const;
     XrResult ValidateQuadLayer(const XrCompositionLayerQuad& layer) const;
 
     uint64_t handle_ = 0;

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -901,6 +901,7 @@ void StreamingServer::EncodeThread()
             {
                 SendNalUnit(packetDispatchState, frameIndex, nalData, nalSize, isKeyframe, timestampNs);
             },
+            frame.snapshotWaitValue,
             [this, telemetry, queueWaitMs, encoder](const VideoEncoder::FrameMetrics& metrics)
             {
                 telemetry->gpuCopyMs.Add(metrics.gpuCopyMs);
@@ -1356,7 +1357,8 @@ void StreamingServer::UpdatePredictionHorizon()
     trackingReceiver_->SetPredictionHorizonMs(horizonMs);
 }
 
-void StreamingServer::SendFrame(void* leftTexture, void* rightTexture)
+void StreamingServer::SendFrame(void* leftTexture, void* rightTexture,
+                                uint64_t snapshotWaitValue)
 {
     if (leftTexture == nullptr || rightTexture == nullptr || state_.load() != State::Connected)
     {
@@ -1388,6 +1390,7 @@ void StreamingServer::SendFrame(void* leftTexture, void* rightTexture)
         pendingFrame_.rightTexture = rightTexture;
         pendingFrame_.frameIndex = frameIndex_++;
         pendingFrame_.timestampNs = SteadyClockNowNs();
+        pendingFrame_.snapshotWaitValue = snapshotWaitValue;
         pendingFrame_.valid = true;
         pendingFrameDepthMax_.store(std::max(pendingFrameDepthMax_.load(), 1u));
 

--- a/runtime/src/StreamingServer.h
+++ b/runtime/src/StreamingServer.h
@@ -54,7 +54,10 @@ public:
 
     // Queue a rendered frame for asynchronous latest-frame-only encoding.
     // leftTexture/rightTexture are retained MTLTexture* views from Swapchain.
-    void SendFrame(void* leftTexture, void* rightTexture);
+    // snapshotWaitValue: the staging-snapshot signal value carried through to the
+    // encoder so its blit waits for the snapshot copy GPU-side before reading.
+    void SendFrame(void* leftTexture, void* rightTexture,
+                   uint64_t snapshotWaitValue = 0);
 
     // Set the Metal device for VideoEncoder initialization
     void SetMetalDevice(void* metalDevice) { metalDevice_ = metalDevice; }
@@ -104,6 +107,9 @@ private:
         uint32_t frameIndex = 0;
         int64_t timestampNs = 0;
         bool valid = false;
+        // This frame's staging-snapshot signal value on the shared event; the encode
+        // blit waits for it (encodeWaitForEvent) before reading the staging texture.
+        uint64_t snapshotWaitValue = 0;
 
         // Render pose at the time this frame was submitted (for ATW correction)
         float headPosition[3] = {};

--- a/runtime/src/Swapchain.h
+++ b/runtime/src/Swapchain.h
@@ -75,6 +75,12 @@ public:
     // Release a texture view obtained from GetLastReleasedTextureSlice.
     static void ReleaseTextureSlice(void* textureSlice);
 
+    // Monotonic value signaled on the shared event by the most recent snapshot.
+    // Before reading the matching staging texture, the encoder waits on this value
+    // (encodeWaitForEvent, a GPU-side wait for the snapshot copy to complete).
+    // 0 means no snapshot yet (the caller falls back to referencing the slot).
+    uint64_t GetLastSnapshotValue() const;
+
     uint32_t GetArraySize() const
     {
         return arraySize_;
@@ -83,6 +89,20 @@ public:
     bool HasReleasedImage() const;
 
     static constexpr uint32_t SwapchainImageCount = 3;
+
+    // Picture-going-backwards root-cause fix: the encoder is asynchronous and reads
+    // a swapchain slot via a blit on its own command queue, while Unity reuses the
+    // same set of slots to render later frames — so the content the encoder reads
+    // gets clobbered by that asynchronous reuse (confirmed by a discriminating
+    // experiment: increasing the buffer count made the contamination span larger
+    // and the judder worse). The fix: at ReleaseImage time, use Unity's own queue
+    // to snapshot the current slot's contents into a separate pool of staging
+    // textures (not part of Unity's reuse cycle), and have GetLastReleasedTextureSlice
+    // return a staging view, so the content the encoder reads is fixed as of release.
+    // Only needs to cover the frames in flight between a slot's release and the encoder
+    // reading its snapshot; with the latest-frame-only encode queue that is ~2-3, so 4
+    // is a safe round-up that keeps the extra resident-texture memory low.
+    static constexpr uint32_t StagingImageCount = 4;
 
 private:
     enum class ImageState
@@ -116,6 +136,14 @@ private:
     uint32_t lastReleasedIndex_ = 0;
     bool staticImageAcquired_ = false;
     bool hasReleasedImage_ = false;
+
+    // Separate snapshot texture pool (see StagingImageCount). Only used on the
+    // Metal path and only once Unity's command queue is available.
+    std::vector<void*> stagingTextures_; // MTL::Texture*, same descriptor as swapchain textures
+    uint32_t stagingWriteIndex_ = 0;     // next staging slot to write (round-robin)
+    uint32_t lastSnapshotIndex_ = 0;     // staging slot of the most recent snapshot
+    uint64_t lastSnapshotValue_ = 0;     // value signaled on the shared event by that snapshot
+    bool hasSnapshot_ = false;           // whether at least one snapshot has been produced
     std::vector<ImageState> imageStates_;
     std::deque<uint32_t> acquiredImageOrder_;
     mutable std::mutex stateMutex_;

--- a/runtime/src/Swapchain.mm
+++ b/runtime/src/Swapchain.mm
@@ -6,6 +6,20 @@
 #include <spdlog/spdlog.h>
 
 #import <Metal/Metal.h>
+#include <atomic>
+
+// Unity's Metal command queue (saved in xrCreateSession, EntryPoint.cpp). Used for
+// the release->read cross-queue synchronization; see ReleaseImage.
+extern void* gUnityMetalCommandQueue;
+
+// Non-blocking cross-queue sync: once a snapshot blit completes, a monotonically
+// increasing value is signaled on this MTLSharedEvent; the encoder (on its own
+// queue) issues encodeWaitForEvent for the matching value before reading the
+// staging texture, so the wait happens GPU-side without blocking the app thread,
+// while still letting Unity's rendering and the encode blit run in parallel.
+// Referenced via extern from VideoEncoder.mm.
+void* gSnapshotEvent = nullptr;               // id<MTLSharedEvent>
+static std::atomic<uint64_t> gSnapshotValue{0};
 
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 #include <vulkan/vulkan.h>
@@ -155,6 +169,26 @@ void Swapchain::InitMetal(void* metalDevice, const XrSwapchainCreateInfo* create
     {
         id<MTLTexture> tex = [device newTextureWithDescriptor:desc];
         textures_[i] = (void*)[tex retain];
+    }
+
+    // Separate staging pool: same descriptor as the swapchain textures, not part
+    // of Unity's acquire/release reuse cycle. At ReleaseImage we snapshot the
+    // current slot into it, and the encoder reads the staging texture instead of
+    // the swapchain slot (avoiding reuse contamination).
+    if (imageCount_ > 1) // a static single-image swapchain has no reuse, so no snapshot needed
+    {
+        stagingTextures_.resize(StagingImageCount);
+        for (uint32_t i = 0; i < StagingImageCount; i++)
+        {
+            id<MTLTexture> tex = [device newTextureWithDescriptor:desc];
+            stagingTextures_[i] = (void*)[tex retain];
+        }
+        // Shared snapshot-sync event (one per process, monotonically increasing value).
+        if (gSnapshotEvent == nullptr)
+        {
+            id<MTLSharedEvent> ev = [device newSharedEvent];
+            gSnapshotEvent = (void*)[ev retain];
+        }
     }
 
     Runtime::Get().RegisterHandle(handle_, this);
@@ -309,6 +343,13 @@ Swapchain::~Swapchain()
             [(id<MTLTexture>)tex release];
         }
     }
+    for (auto* tex : stagingTextures_)
+    {
+        if (tex)
+        {
+            [(id<MTLTexture>)tex release];
+        }
+    }
     Runtime::Get().RemoveHandle(handle_);
 }
 
@@ -457,12 +498,48 @@ XrResult Swapchain::ReleaseImage(const XrSwapchainImageReleaseInfo* releaseInfo)
     imageStates_[releaseIndex] = ImageState::Available;
     hasReleasedImage_ = true;
     acquiredImageOrder_.pop_front();
+
+    // Picture-going-backwards root-cause fix (non-blocking): use Unity's own command
+    // queue to snapshot this frame's slot into a separate staging texture. The blit
+    // is submitted on Unity's queue, so it runs after the app's render commands for
+    // this frame -> it reads the correct rendered result. Instead of blocking the app
+    // thread with waitUntilCompleted, we signal a monotonic value on the shared event
+    // once the blit completes; the encoder issues encodeWaitForEvent for that value
+    // (a GPU-side wait) before reading the staging texture. The encoder thus reads
+    // content fixed as of release time, unaffected by Unity reusing the slot later.
+    // When Unity's queue is unavailable, fall back to referencing the slot directly.
+    if (gUnityMetalCommandQueue != nullptr && !stagingTextures_.empty() && gSnapshotEvent != nullptr)
+    {
+        id<MTLCommandQueue> unityQueue = (__bridge id<MTLCommandQueue>)gUnityMetalCommandQueue;
+        id<MTLTexture> src = (__bridge id<MTLTexture>)textures_[lastReleasedIndex_];
+        id<MTLTexture> dst = (__bridge id<MTLTexture>)stagingTextures_[stagingWriteIndex_];
+        if (src != nil && dst != nil)
+        {
+            uint64_t signalValue = ++gSnapshotValue;
+            id<MTLCommandBuffer> cb = [unityQueue commandBuffer];
+            id<MTLBlitCommandEncoder> blit = [cb blitCommandEncoder];
+            [blit copyFromTexture:src toTexture:dst];
+            [blit endEncoding];
+            [cb encodeSignalEvent:(id<MTLSharedEvent>)gSnapshotEvent value:signalValue];
+            [cb commit]; // non-blocking: do not wait for GPU completion
+            lastSnapshotIndex_ = stagingWriteIndex_;
+            lastSnapshotValue_ = signalValue;
+            stagingWriteIndex_ = (stagingWriteIndex_ + 1) % StagingImageCount;
+            hasSnapshot_ = true;
+        }
+    }
+
     return XR_SUCCESS;
 }
 
 // ============================================================================
 // GetLastReleasedTexture — always returns MTLTexture* (for debug renderer)
 // ============================================================================
+
+uint64_t Swapchain::GetLastSnapshotValue() const
+{
+    return lastSnapshotValue_;
+}
 
 void* Swapchain::GetLastReleasedTexture() const
 {
@@ -480,7 +557,15 @@ void* Swapchain::GetLastReleasedTextureSlice(uint32_t arrayIndex) const
         return nullptr;
     }
 
-    id<MTLTexture> tex = (id<MTLTexture>)textures_[lastReleasedIndex_];
+    // Picture-going-backwards root-cause fix: prefer the independent snapshot copied
+    // at release time (not subject to Unity reuse contamination); when there is no
+    // snapshot (Vulkan path / Unity queue unavailable), fall back to the swapchain slot.
+    void* srcTex = textures_[lastReleasedIndex_];
+    if (hasSnapshot_ && lastSnapshotIndex_ < stagingTextures_.size())
+    {
+        srcTex = stagingTextures_[lastSnapshotIndex_];
+    }
+    id<MTLTexture> tex = (id<MTLTexture>)srcTex;
     if (!tex)
     {
         return nullptr;

--- a/runtime/src/VideoEncoder.h
+++ b/runtime/src/VideoEncoder.h
@@ -56,8 +56,13 @@ public:
 
     // Encode two Metal textures side-by-side (left eye | right eye)
     // The combined image has double the width of a single eye
+    // snapshotWaitValue: the signal value of this frame's staging snapshot on the
+    // shared event. Before the encode blit reads the staging texture it waits for
+    // this value GPU-side (encodeWaitForEvent), ensuring the snapshot copy is done
+    // without blocking the app thread. 0 = do not wait.
     bool EncodeStereo(void* leftTexture, void* rightTexture,
                       int64_t timestampNs, OnNalUnitCallback callback,
+                      uint64_t snapshotWaitValue = 0,
                       OnFrameEncodedCallback frameCallback = {});
 
     // Force a keyframe on the next encode
@@ -86,6 +91,7 @@ private:
 
     bool EncodeInternal(void* leftTexture, void* rightTexture, bool stereo,
                         int64_t timestampNs, OnNalUnitCallback callback,
+                        uint64_t snapshotWaitValue,
                         OnFrameEncodedCallback frameCallback);
     bool AcquireSlot(size_t& outSlotIndex);
     void ReleaseSlot(size_t slotIndex);

--- a/runtime/src/VideoEncoder.mm
+++ b/runtime/src/VideoEncoder.mm
@@ -443,19 +443,25 @@ bool VideoEncoder::Encode(void* metalTexture, int64_t timestampNs, OnNalUnitCall
                            OnFrameEncodedCallback frameCallback)
 {
     return EncodeInternal(metalTexture, nullptr, false, timestampNs,
-                          std::move(callback), std::move(frameCallback));
+                          std::move(callback), 0, std::move(frameCallback));
 }
 
 bool VideoEncoder::EncodeStereo(void* leftTexture, void* rightTexture,
                                  int64_t timestampNs, OnNalUnitCallback callback,
+                                 uint64_t snapshotWaitValue,
                                  OnFrameEncodedCallback frameCallback)
 {
     return EncodeInternal(leftTexture, rightTexture, true, timestampNs,
-                          std::move(callback), std::move(frameCallback));
+                          std::move(callback), snapshotWaitValue, std::move(frameCallback));
 }
+
+// Shared snapshot-sync event (defined in Swapchain.mm). Before the encode blit reads
+// the staging texture, encodeWaitForEvent waits on it.
+extern void* gSnapshotEvent;
 
 bool VideoEncoder::EncodeInternal(void* leftTexture, void* rightTexture, bool stereo,
                                    int64_t timestampNs, OnNalUnitCallback callback,
+                                   uint64_t snapshotWaitValue,
                                    OnFrameEncodedCallback frameCallback)
 {
     if (session_ == nullptr || leftTexture == nullptr || (stereo && rightTexture == nullptr))
@@ -499,6 +505,15 @@ bool VideoEncoder::EncodeInternal(void* leftTexture, void* rightTexture, bool st
     {
         ReleaseSlot(slotIndex);
         return false;
+    }
+
+    // Non-blocking cross-queue sync: before this command buffer (on the encoder's own
+    // queue) reads the staging texture, wait GPU-side for the frame's snapshot blit to
+    // complete (the value Swapchain signaled on Unity's queue). The CPU does not block,
+    // preserving parallelism.
+    if (gSnapshotEvent != nullptr && snapshotWaitValue > 0)
+    {
+        [cmdBuf encodeWaitForEvent:(id<MTLSharedEvent>)gSnapshotEvent value:snapshotWaitValue];
     }
 
     bool forceKeyframe = forceKeyframe_.exchange(false);


### PR DESCRIPTION
## Problem

When streaming a Unity (Metal) app, the picture intermittently steps backwards on fast head motion. The encoder reads the swapchain slot on its own queue via `GetLastReleasedTextureSlice()`, with nothing ordering that read against the app's render into the slot. Since the app cycles through and reuses slots, an unsynchronized read can land on a slot whose current-frame render hasn't completed yet and pick up its older previous contents — so the encoded frame goes backwards.
## Fix

At `xrReleaseSwapchainImage`, snapshot the just-released slot into a **separate pool of staging textures** using the app's own Metal command queue, and have the encoder read the staging copy instead of the live slot.

## Cost / safety

- **Memory**: `StagingImageCount = 4` full-size textures per swapchain, enough to cover the in-flight release→encode window.
- **Falls back to current behavior**: if the app's Metal command queue is unavailable it references the slot directly, as before. The Vulkan path likely has the same race, but I have no setup to test a fix there, so it's left untouched.

## Testing

Unity (Metal) + the macOS simulator viewer, fast yaw sweep: the backwards stepping is gone — encoder input no longer reverts to an earlier frame's content.
