### PR TITLE
Fix/vision pro black screen and eye projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Filtered known macOS `linkd.autoShortcut` App Intents diagnostics from Home captured app logs.
 - Fixed and covered `xrLocateSpacesKHR` as an alias for the OpenXR 1.1 `xrLocateSpaces` entry point.
 - Fixed the visionOS viewer black screen and doubled AR view by sharing one ARKit world-tracking session between the tracking manager and the immersive renderer, and clearing the drawable depth buffer so the visionOS compositor has a surface to reproject.
+- Fixed visionOS eye projection by sending the device's real per-eye FOV (OpenXR signed angles) and IPD to the runtime, so it renders a matching frustum instead of the symmetric fallback that made the projection look wrong.
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Fixed a Unity editor crash on session shutdown by invalidating stale VideoToolbox encode callbacks before the streaming server is destroyed and by catching callback exceptions inside the encoder.
 - Filtered known macOS `linkd.autoShortcut` App Intents diagnostics from Home captured app logs.
 - Fixed and covered `xrLocateSpacesKHR` as an alias for the OpenXR 1.1 `xrLocateSpaces` entry point.
+- Fixed the visionOS viewer black screen and doubled AR view by sharing one ARKit world-tracking session between the tracking manager and the immersive renderer, and clearing the drawable depth buffer so the visionOS compositor has a surface to reproject.
 
 ### Documentation
 

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+import ARKit
 import CoreMedia
 import CoreVideo
 import Foundation
@@ -241,6 +242,12 @@ final class AppModel {
 
     var refreshRate: Int {
         Int(discoveredServer?.refreshRate ?? 90)
+    }
+
+    /// Shared with the immersive renderer so device anchors come from one running ARKit
+    /// session; two separate world-tracking providers conflict and return nil anchors.
+    var sharedWorldTracking: WorldTrackingProvider {
+        trackingManager.worldTracking
     }
 
     func startDiscovery() {

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
@@ -66,6 +66,25 @@ private final class KeyframeRecoveryState: @unchecked Sendable {
     }
 }
 
+private final class EyeProjectionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fovAngles = SIMD4<Float>(repeating: 0) // angleLeft, angleRight, angleUp, angleDown (radians)
+    private var ipd: Float = 0
+
+    func set(fovAngles: SIMD4<Float>, ipd: Float) {
+        lock.lock()
+        self.fovAngles = fovAngles
+        self.ipd = ipd
+        lock.unlock()
+    }
+
+    func get() -> (fovAngles: SIMD4<Float>, ipd: Float) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (fovAngles, ipd)
+    }
+}
+
 @MainActor
 @Observable
 final class AppModel {
@@ -112,6 +131,7 @@ final class AppModel {
     private let trackingManager = VisionTrackingManager()
     private nonisolated let pixelBufferState = PixelBufferState()
     private nonisolated let keyframeRecoveryState = KeyframeRecoveryState()
+    private nonisolated let eyeProjectionState = EyeProjectionState()
 
     private var statsTimer: Timer?
     private var lastStatsTimeNs: Int64 = 0
@@ -136,7 +156,16 @@ final class AppModel {
                 snapshot.orientation.imag.z,
                 snapshot.orientation.real
             )
-            packet.ipd = 0.064
+            let eyeProjection = self.eyeProjectionState.get()
+            packet.ipd = eyeProjection.ipd > 0 ? eyeProjection.ipd : 0.064
+            if eyeProjection.fovAngles != SIMD4<Float>(repeating: 0) {
+                packet.eyeFov = (
+                    eyeProjection.fovAngles.x,
+                    eyeProjection.fovAngles.y,
+                    eyeProjection.fovAngles.z,
+                    eyeProjection.fovAngles.w
+                )
+            }
 
             if let leftHand = snapshot.leftHand {
                 packet.trackingFlags |= TrackingFlagsValues.leftHandActive
@@ -417,6 +446,12 @@ final class AppModel {
 
     nonisolated func currentPixelBuffer() -> CVPixelBuffer? {
         pixelBufferState.get()
+    }
+
+    /// Called from the render loop with the device's real per-eye FOV (radians, OpenXR
+    /// signed angles) and IPD, forwarded to the runtime so it renders the matching frustum.
+    nonisolated func updateEyeProjection(fovAngles: SIMD4<Float>, ipd: Float) {
+        eyeProjectionState.set(fovAngles: fovAngles, ipd: ipd)
     }
 
     private func resolvedServerAddress(for server: DiscoveredServer) -> String {

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
@@ -45,6 +45,7 @@ actor ImmersiveRenderer {
     private let endFrameEvent: MTLSharedEvent
 
     private var committedFrameIndex: UInt64 = UInt64(ImmersiveRendererConstants.maxBuffersInFlight)
+    private var didLogProjection = false
 
     init(layerRenderer: LayerRenderer, appModel: AppModel, worldTracking: WorldTrackingProvider) {
         self.layerRenderer = layerRenderer
@@ -137,6 +138,8 @@ actor ImmersiveRenderer {
         let presentationTime = drawable.frameTiming.presentationTime.timeInterval
         drawable.deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: presentationTime)
 
+        publishEyeProjection(drawable)
+
         let renderPassDescriptor = MTLRenderPassDescriptor()
         renderPassDescriptor.colorAttachments[0].texture = drawable.colorTextures[0]
         renderPassDescriptor.colorAttachments[0].loadAction = .clear
@@ -185,6 +188,33 @@ actor ImmersiveRenderer {
         encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
         encoder.endEncoding()
         drawable.encodePresent(commandBuffer: commandBuffer)
+    }
+
+    /// Sends the device's real per-eye FOV (radians, OpenXR signed angles) and IPD so the
+    /// runtime renders the matching frustum instead of its symmetric fallback FOV. visionOS
+    /// view tangents are positive magnitudes in (left, right, up, down) order, so negate the
+    /// left and down components to produce OpenXR's signed XrFovf angles.
+    private func publishEyeProjection(_ drawable: LayerRenderer.Drawable) {
+        guard let leftView = drawable.views.first else { return }
+        let t = leftView.tangents
+        let fovAngles = SIMD4<Float>(-atan(t.x), atan(t.y), atan(t.z), -atan(t.w))
+
+        let leftEye = leftView.transform.columns.3
+        let rightEye = (drawable.views.count > 1 ? drawable.views[1] : leftView).transform.columns.3
+        let dx = rightEye.x - leftEye.x, dy = rightEye.y - leftEye.y, dz = rightEye.z - leftEye.z
+        let ipd = (dx * dx + dy * dy + dz * dz).squareRoot()
+
+        if !didLogProjection {
+            didLogProjection = true
+            print("[ProjDiag] L.tangents=(\(t.x), \(t.y), \(t.z), \(t.w))")
+            if drawable.views.count > 1 {
+                let rt = drawable.views[1].tangents
+                print("[ProjDiag] R.tangents=(\(rt.x), \(rt.y), \(rt.z), \(rt.w))")
+            }
+            print("[ProjDiag] fovAngles(rad)=(\(fovAngles.x), \(fovAngles.y), \(fovAngles.z), \(fovAngles.w)) ipd=\(ipd)")
+        }
+
+        appModel.updateEyeProjection(fovAngles: fovAngles, ipd: ipd)
     }
 
     private func makeTexture(from pixelBuffer: CVPixelBuffer, plane: Int, format: MTLPixelFormat) -> MTLTexture? {

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
@@ -39,16 +39,17 @@ actor ImmersiveRenderer {
     private unowned let appModel: AppModel
     private let device: MTLDevice
     private let commandQueue: MTLCommandQueue
-    private let worldTracking = WorldTrackingProvider()
+    private let worldTracking: WorldTrackingProvider
     private let textureCache: CVMetalTextureCache
     private let pipelineState: MTLRenderPipelineState
     private let endFrameEvent: MTLSharedEvent
 
     private var committedFrameIndex: UInt64 = UInt64(ImmersiveRendererConstants.maxBuffersInFlight)
 
-    init(layerRenderer: LayerRenderer, appModel: AppModel) {
+    init(layerRenderer: LayerRenderer, appModel: AppModel, worldTracking: WorldTrackingProvider) {
         self.layerRenderer = layerRenderer
         self.appModel = appModel
+        self.worldTracking = worldTracking
         self.device = layerRenderer.device
         self.commandQueue = layerRenderer.device.makeCommandQueue()!
 
@@ -62,6 +63,7 @@ actor ImmersiveRenderer {
         pipelineDescriptor.vertexFunction = library.makeFunction(name: "stereoImmersiveVertex")
         pipelineDescriptor.fragmentFunction = library.makeFunction(name: "stereoImmersiveFragment")
         pipelineDescriptor.colorAttachments[0].pixelFormat = layerRenderer.configuration.colorFormat
+        pipelineDescriptor.depthAttachmentPixelFormat = layerRenderer.configuration.depthFormat
         pipelineDescriptor.maxVertexAmplificationCount = layerRenderer.properties.viewCount
         self.pipelineState = try! device.makeRenderPipelineState(descriptor: pipelineDescriptor)
 
@@ -69,19 +71,10 @@ actor ImmersiveRenderer {
         self.endFrameEvent.signaledValue = committedFrameIndex
     }
 
-    private func startARSession(_ arSession: ARKitSession) async {
-        do {
-            try await arSession.run([worldTracking])
-        } catch {
-            print("[VisionImmersive] Failed to start ARKitSession: \(error)")
-        }
-    }
-
     @MainActor
-    static func startRenderLoop(_ layerRenderer: LayerRenderer, appModel: AppModel, arSession: ARKitSession) {
+    static func startRenderLoop(_ layerRenderer: LayerRenderer, appModel: AppModel, worldTracking: WorldTrackingProvider) {
         Task(executorPreference: ImmersiveRendererTaskExecutor.shared) {
-            let renderer = ImmersiveRenderer(layerRenderer: layerRenderer, appModel: appModel)
-            await renderer.startARSession(arSession)
+            let renderer = ImmersiveRenderer(layerRenderer: layerRenderer, appModel: appModel, worldTracking: worldTracking)
             await renderer.renderLoop()
         }
     }
@@ -149,6 +142,14 @@ actor ImmersiveRenderer {
         renderPassDescriptor.colorAttachments[0].loadAction = .clear
         renderPassDescriptor.colorAttachments[0].storeAction = .store
         renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
+        // visionOS reprojects each presented frame using the depth buffer; with no valid depth
+        // the device drops every frame (black) while the simulator does not. Clear the depth to
+        // a fixed head-locked distance so the compositor has a real surface to reproject.
+        let clip = drawable.computeProjection(viewIndex: 0) * SIMD4<Float>(0, 0, -2.0, 1)
+        renderPassDescriptor.depthAttachment.texture = drawable.depthTextures[0]
+        renderPassDescriptor.depthAttachment.loadAction = .clear
+        renderPassDescriptor.depthAttachment.storeAction = .store
+        renderPassDescriptor.depthAttachment.clearDepth = clip.w != 0 ? Double(clip.z / clip.w) : 0
         renderPassDescriptor.rasterizationRateMap = drawable.rasterizationRateMaps.first
         if layerRenderer.configuration.layout == .layered {
             renderPassDescriptor.renderTargetArrayLength = drawable.views.count

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/OXRSysVisionOSApp.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/OXRSysVisionOSApp.swift
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-import ARKit
 import CompositorServices
 import SwiftUI
 
@@ -9,7 +8,7 @@ struct ImmersiveSpaceContent: CompositorContent {
 
     var body: some CompositorContent {
         CompositorLayer(configuration: self) { @MainActor layerRenderer in
-            ImmersiveRenderer.startRenderLoop(layerRenderer, appModel: appModel, arSession: ARKitSession())
+            ImmersiveRenderer.startRenderLoop(layerRenderer, appModel: appModel, worldTracking: appModel.sharedWorldTracking)
         }
     }
 }

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/VisionTrackingManager.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/VisionTrackingManager.swift
@@ -35,7 +35,7 @@ struct VisionTrackingSnapshot: Sendable {
 
 final class VisionTrackingManager: @unchecked Sendable {
     private let session = ARKitSession()
-    private let worldTracking = WorldTrackingProvider()
+    let worldTracking = WorldTrackingProvider()
     private let handTracking = HandTrackingProvider()
     private let queue = DispatchQueue(label: "oxr.visionos.tracking", qos: .userInteractive)
 

--- a/docs/platforms/visionos.md
+++ b/docs/platforms/visionos.md
@@ -11,9 +11,9 @@ The visionOS target is a first-pass native viewer that fits the Apple platform m
 - runtime discovery on the local network
 - a minimal floating control window with a `Search` action
 - UDP stream connection through the shared `OXRSysStreaming` package
-- immersive stereo presentation through a native Metal compositor layer
+- immersive stereo presentation through a native Metal compositor layer, on a single shared ARKit world-tracking session with a depth-backed drawable so the compositor can reproject
 - automatic immersive VR entry once the stream is connected
-- 6DOF head-pose return while the immersive space is open
+- 6DOF head-pose return while the immersive space is open, including the device's real per-eye FOV and IPD so the runtime renders a matching frustum
 - hand-joint streaming through the shared 26-joint tracking payload
 - first-pass accessory controller pose and input streaming when a tracked spatial controller is available
 


### PR DESCRIPTION
[Issue](https://github.com/demonixis/oxrsys/issues/9)

### Problem
  Two issues kept the visionOS viewer from rendering a usable stereo image.
  
  Black screen + doubled AR view. The tracking manager and the immersive renderer each created their own
  WorldTrackingProvider. Two world-tracking providers in one ARKit session conflict and return nil device anchors, so
  the compositor never received a head pose. Separately, the drawable was presented with no valid depth — visionOS
  reprojects every presented frame from the depth buffer, so with degenerate depth the device dropped every frame and
  the view stayed black. (The macOS simulator doesn't reproject the same way, which is why it looked fine there.)

  Wrong eye projection. The client never sent the headset's real per-eye FOV or IPD, so the runtime fell back to a
  symmetric placeholder FOV. Vision Pro's per-eye frustums are asymmetric and mirrored left/right, so the fallback
  pushed each eye outward — left eye too far left, right eye too far right.

###   Fix
  - Share a single ARKit world-tracking session between the tracking manager and the immersive renderer, so device
  anchors resolve and the black screen / doubling go away.             
  - Clear the drawable depth buffer to a fixed head-locked distance so the visionOS compositor has a real surface to
  reproject.
  - Send the device's real per-eye FOV (OpenXR signed angles) and IPD from the viewer to the runtime, so it renders the
  matching frustum instead of the symmetric fallback.
  
###   Testing
  - visionOS hardware: Apple Vision Pro (M5) streaming from a Mac M5 Pro — correctly-projected stereo image: no
  black screen and the eyes converge correctly.
  - xcodebuild … -destination 'generic/platform=visionOS Simulator' build passes.

