### PR TITLE
Vision Pro: world-space reprojection + head-rotation jitter fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Added a local Quest/PICO shell that replaces standby/loading color clears with a 3D grid, upright status panel, reset button, optional `XR_FB_passthrough` mode, controller laser interaction, hand laser/pinch interaction, and visible hand-joint markers.
 - Added a runtime ABR controller with `off`, `bitrate`, and `full` modes, sliding-window hysteresis, fast bitrate downshift, slow recovery, and profile reporting for future session-safe resolution/foveation/upscaling transitions.
 - Added protocol v1.2 stream reconfiguration (`StreamConfigUpdate/Ack`) for reliable USB TCP, dynamic encoded-resolution profiles for `abr_mode = "full"`, global passthrough config with app-driven OpenXR alpha blend/source-alpha detection, headset passthrough support/readiness status, occlusion/spatial config gates, a reserved optional spatial TCP channel on `9948`, and matching SwiftUI/Qt Home controls and status display.
+- Added world-space (rotational) reprojection to the visionOS viewer: each streamed frame is reprojected from the head pose the runtime rendered it for into the live head pose every vsync, so the view stays locked to the world as the head turns instead of lagging the stream. It reuses the per-frame `VIDEO_FLAG_RENDER_POSE` the runtime already sends and is client-only (no runtime, protocol, or other-client changes).
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Fixed and covered `xrLocateSpacesKHR` as an alias for the OpenXR 1.1 `xrLocateSpaces` entry point.
 - Fixed the visionOS viewer black screen and doubled AR view by sharing one ARKit world-tracking session between the tracking manager and the immersive renderer, and clearing the drawable depth buffer so the visionOS compositor has a surface to reproject.
 - Fixed visionOS eye projection by sending the device's real per-eye FOV (OpenXR signed angles) and IPD to the runtime, so it renders a matching frustum instead of the symmetric fallback that made the projection look wrong.
+- Fixed Vision Pro head-rotation jitter at the source: the runtime now tags each streamed frame with the exact head pose the application rendered it for (captured at `xrLocateViews`) instead of a pose re-predicted at frame submission, so the headset client reprojects against a pose that matches the pixels. It also drops out-of-order/duplicate UDP tracking packets by the client's monotonic timestamp so finite-difference prediction cannot emit a bogus angular velocity from a reordered sample.
 
 ### Documentation
 

--- a/clients/Apple/common/OXRSysStreaming/Sources/OXRSysStreaming/VideoReceiver.swift
+++ b/clients/Apple/common/OXRSysStreaming/Sources/OXRSysStreaming/VideoReceiver.swift
@@ -11,6 +11,9 @@ import os
 
 public final class VideoReceiver: @unchecked Sendable {
     public typealias OnNalUnit = @Sendable (Data, Int64, Int64) -> Void
+    /// (presentationTimeNs, orientation xyzw) — the head orientation the server rendered this
+    /// frame for, echoed back so the client can reproject the frame to the live head pose.
+    public typealias OnRenderPose = @Sendable (Int64, (Float, Float, Float, Float)) -> Void
 
     private struct State {
         var socket: Int32 = -1
@@ -34,7 +37,7 @@ public final class VideoReceiver: @unchecked Sendable {
 
     public init() {}
 
-    public func start(onNalUnit: @escaping OnNalUnit) {
+    public func start(onNalUnit: @escaping OnNalUnit, onRenderPose: OnRenderPose? = nil) {
         let shouldStart = state.withLock { state in
             if state.running {
                 return false
@@ -97,7 +100,7 @@ public final class VideoReceiver: @unchecked Sendable {
             }
             print("[VideoRecv] Listening on port \(OXRProtocol.videoPort)")
 
-            self.receiveLoop(fd: fd, onNalUnit: onNalUnit)
+            self.receiveLoop(fd: fd, onNalUnit: onNalUnit, onRenderPose: onRenderPose)
 
             let shouldClose = state.withLock { state in
                 state.running = false
@@ -135,7 +138,7 @@ public final class VideoReceiver: @unchecked Sendable {
 
     // MARK: - Receive loop (raw memory, zero-copy hot path)
 
-    private func receiveLoop(fd: Int32, onNalUnit: @escaping OnNalUnit) {
+    private func receiveLoop(fd: Int32, onNalUnit: @escaping OnNalUnit, onRenderPose: OnRenderPose?) {
         let headerSize = MemoryLayout<VideoPacketHeader>.size
         let maxPacketSize = headerSize + OXRProtocol.maxPacketPayload
 
@@ -262,8 +265,17 @@ public final class VideoReceiver: @unchecked Sendable {
             let header = UnsafeRawPointer(recvBuf).loadUnaligned(as: VideoPacketHeader.self)
             let payloadSize = min(Int(header.payloadSize), n - headerSize)
 
-            // Render pose packet — skip (handled separately if needed)
+            // Render pose packet — the head pose the server rendered this frame for. The payload
+            // is position xyz then orientation xyzw (7 floats); we use the orientation to reproject.
             if header.flags & VideoFlags.renderPose != 0 {
+                if let onRenderPose, payloadSize >= MemoryLayout<Float>.size * 7 {
+                    let base = UnsafeRawPointer(recvBuf + headerSize)
+                    let ox = base.loadUnaligned(fromByteOffset: 12, as: Float.self)
+                    let oy = base.loadUnaligned(fromByteOffset: 16, as: Float.self)
+                    let oz = base.loadUnaligned(fromByteOffset: 20, as: Float.self)
+                    let ow = base.loadUnaligned(fromByteOffset: 24, as: Float.self)
+                    onRenderPose(header.presentationTimeNs, (ox, oy, oz, ow))
+                }
                 continue
             }
 

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/AppModel.swift
@@ -14,10 +14,12 @@ import simd
 private final class PixelBufferState: @unchecked Sendable {
     private let lock = NSLock()
     private var pixelBuffer: CVPixelBuffer?
+    private var presentationTimeNs: Int64 = 0
 
-    func set(_ newValue: CVPixelBuffer?) {
+    func set(_ newValue: CVPixelBuffer?, presentationTimeNs: Int64) {
         lock.lock()
         pixelBuffer = newValue
+        self.presentationTimeNs = presentationTimeNs
         lock.unlock()
     }
 
@@ -26,6 +28,14 @@ private final class PixelBufferState: @unchecked Sendable {
         let value = pixelBuffer
         lock.unlock()
         return value
+    }
+
+    /// The displayed frame and the presentation timestamp it was tagged with, read together so
+    /// the renderer reprojects that exact frame with the render pose that belongs to it.
+    func getWithTimestamp() -> (pixelBuffer: CVPixelBuffer?, presentationTimeNs: Int64) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (pixelBuffer, presentationTimeNs)
     }
 }
 
@@ -85,6 +95,38 @@ private final class EyeProjectionState: @unchecked Sendable {
     }
 }
 
+/// Stores the head orientation the server rendered each frame for, keyed by the frame's
+/// presentation timestamp, so the renderer can reproject the displayed frame to the live pose.
+private final class RenderPoseReprojector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var orientationByPresentationNs: [Int64: simd_quatf] = [:]
+    private let capacity = 240   // ring-buffer cap (~a few seconds of frames); bounds memory only
+    private var latestKey: Int64 = 0
+    private var latestOrientation: simd_quatf?
+
+    func note(presentationTimeNs: Int64, orientation: simd_quatf) {
+        lock.lock()
+        orientationByPresentationNs[presentationTimeNs] = orientation
+        if presentationTimeNs >= latestKey {
+            latestKey = presentationTimeNs
+            latestOrientation = orientation
+        }
+        if orientationByPresentationNs.count > capacity,
+           let oldest = orientationByPresentationNs.keys.min() {
+            orientationByPresentationNs.removeValue(forKey: oldest)
+        }
+        lock.unlock()
+    }
+
+    /// Exact render pose for this frame, falling back to the most recent one if this frame's pose
+    /// packet was lost (it's a single un-FEC'd UDP packet) — exact match first, recent pose second.
+    func orientation(forPresentationTimeNs presentationTimeNs: Int64) -> simd_quatf? {
+        lock.lock()
+        defer { lock.unlock() }
+        return orientationByPresentationNs[presentationTimeNs] ?? latestOrientation
+    }
+}
+
 @MainActor
 @Observable
 final class AppModel {
@@ -132,6 +174,7 @@ final class AppModel {
     private nonisolated let pixelBufferState = PixelBufferState()
     private nonisolated let keyframeRecoveryState = KeyframeRecoveryState()
     private nonisolated let eyeProjectionState = EyeProjectionState()
+    private nonisolated let renderPoseReprojector = RenderPoseReprojector()
 
     private var statsTimer: Timer?
     private var lastStatsTimeNs: Int64 = 0
@@ -308,7 +351,7 @@ final class AppModel {
         decoder.configure { [weak self] pixelBuffer, presentationTime in
             guard let self else { return }
             self.keyframeRecoveryState.noteDecodedFrame()
-            self.pixelBufferState.set(pixelBuffer)
+            self.pixelBufferState.set(pixelBuffer, presentationTimeNs: Self.nanoseconds(from: presentationTime))
 
             self.latencyReporter.noteFrameDecoded(
                 presentationTimeNs: Self.nanoseconds(from: presentationTime),
@@ -335,14 +378,17 @@ final class AppModel {
             }
         }
 
-        videoReceiver.start { [weak self] nalData, presentationTimeNs, receiveTimeNs in
+        videoReceiver.start(onNalUnit: { [weak self] nalData, presentationTimeNs, receiveTimeNs in
             guard let self else { return }
             self.latencyReporter.noteFrameReceived(
                 presentationTimeNs: presentationTimeNs,
                 receiveTimeNs: receiveTimeNs
             )
             self.decoder.decode(nalData: nalData, presentationTimeNs: presentationTimeNs)
-        }
+        }, onRenderPose: { [weak self] presentationTimeNs, orientation in
+            let quat = simd_quatf(ix: orientation.0, iy: orientation.1, iz: orientation.2, r: orientation.3)
+            self?.renderPoseReprojector.note(presentationTimeNs: presentationTimeNs, orientation: quat)
+        })
 
         Thread.sleep(forTimeInterval: 0.05)
 
@@ -378,7 +424,7 @@ final class AppModel {
         isTrackingActive = false
         stats = StreamStats()
         statusText = "Tap Search to find the runtime"
-        pixelBufferState.set(nil)
+        pixelBufferState.set(nil, presentationTimeNs: 0)
         keyframeRecoveryState.reset()
     }
 
@@ -446,6 +492,18 @@ final class AppModel {
 
     nonisolated func currentPixelBuffer() -> CVPixelBuffer? {
         pixelBufferState.get()
+    }
+
+    /// The displayed frame and its presentation timestamp, snapshotted together so the renderer
+    /// reprojects that exact frame with the render pose that belongs to it.
+    nonisolated func currentFrame() -> (pixelBuffer: CVPixelBuffer?, presentationTimeNs: Int64) {
+        pixelBufferState.getWithTimestamp()
+    }
+
+    /// The head orientation the frame with this presentation timestamp was rendered for, used by
+    /// the renderer to reproject it to the live head pose.
+    nonisolated func renderOrientation(forPresentationTimeNs presentationTimeNs: Int64) -> simd_quatf? {
+        renderPoseReprojector.orientation(forPresentationTimeNs: presentationTimeNs)
     }
 
     /// Called from the render loop with the device's real per-eye FOV (radians, OpenXR

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/ImmersiveRenderer.swift
@@ -5,6 +5,7 @@ import CompositorServices
 import CoreVideo
 import Metal
 import os
+import simd
 
 nonisolated private enum ImmersiveRendererConstants {
     static let maxBuffersInFlight = 3
@@ -46,6 +47,13 @@ actor ImmersiveRenderer {
 
     private var committedFrameIndex: UInt64 = UInt64(ImmersiveRendererConstants.maxBuffersInFlight)
     private var didLogProjection = false
+
+    /// Per-eye reprojection data for the fragment shader: the rotation from the current-eye frame
+    /// into the render-eye frame, plus that eye's frustum tangents.
+    struct ReprojData {
+        var rot: simd_float3x3       // current-eye → render-eye rotation (R_render⁻¹ · R_current)
+        var tangents: SIMD4<Float>   // (left, right, up, down) positive tangent magnitudes
+    }
 
     init(layerRenderer: LayerRenderer, appModel: AppModel, worldTracking: WorldTrackingProvider) {
         self.layerRenderer = layerRenderer
@@ -136,9 +144,20 @@ actor ImmersiveRenderer {
 
     private func render(drawable: LayerRenderer.Drawable, commandBuffer: MTLCommandBuffer) {
         let presentationTime = drawable.frameTiming.presentationTime.timeInterval
-        drawable.deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: presentationTime)
+        let currentAnchor = worldTracking.queryDeviceAnchor(atTimestamp: presentationTime)
+        drawable.deviceAnchor = currentAnchor
 
         publishEyeProjection(drawable)
+
+        // Pair the displayed frame with the render pose it was drawn for, and reproject it into
+        // the live head pose. The compositor still does its small predicted→actual pass via
+        // deviceAnchor; this handles the larger render-pose→now rotation.
+        let frame = appModel.currentFrame()
+        let currentOrientation = currentAnchor.map { headOrientation(from: $0) }
+        let renderOrientation = appModel.renderOrientation(forPresentationTimeNs: frame.presentationTimeNs)
+        var reprojData = reprojectionData(drawable: drawable,
+                                          currentOrientation: currentOrientation,
+                                          renderOrientation: renderOrientation)
 
         let renderPassDescriptor = MTLRenderPassDescriptor()
         renderPassDescriptor.colorAttachments[0].texture = drawable.colorTextures[0]
@@ -178,7 +197,9 @@ actor ImmersiveRenderer {
             encoder.setVertexAmplificationCount(viewports.count, viewMappings: &viewMappings)
         }
 
-        if let pixelBuffer = appModel.currentPixelBuffer(),
+        encoder.setFragmentBytes(&reprojData, length: MemoryLayout<ReprojData>.stride * reprojData.count, index: 0)
+
+        if let pixelBuffer = frame.pixelBuffer,
            let luma = makeTexture(from: pixelBuffer, plane: 0, format: .r8Unorm),
            let chroma = makeTexture(from: pixelBuffer, plane: 1, format: .rg8Unorm) {
             encoder.setFragmentTexture(luma, index: 0)
@@ -188,6 +209,43 @@ actor ImmersiveRenderer {
         encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
         encoder.endEncoding()
         drawable.encodePresent(commandBuffer: commandBuffer)
+    }
+
+    /// Builds per-eye reprojection data: the rotation mapping a current-eye ray into the render
+    /// pose's eye frame, plus that eye's frustum tangents. Identity rotation (no render pose yet,
+    /// or no head motion since the frame was rendered) is an exact passthrough.
+    private func reprojectionData(drawable: LayerRenderer.Drawable,
+                                  currentOrientation: simd_quatf?,
+                                  renderOrientation: simd_quatf?) -> [ReprojData] {
+        let viewCount = max(drawable.views.count, 1)
+        var data: [ReprojData] = (0..<viewCount).map { index in
+            let tangents = index < drawable.views.count
+                ? drawable.views[index].tangents
+                : SIMD4<Float>(1, 1, 1, 1)
+            return ReprojData(rot: matrix_identity_float3x3, tangents: tangents)
+        }
+
+        guard let currentOrientation, let renderOrientation else {
+            return data
+        }
+
+        // dir_render = (R_render⁻¹ · R_current) · dir_current, so the shader finds which texel of
+        // the server-rendered frame each live output ray maps to.
+        let rot = simd_float3x3(simd_normalize(renderOrientation.inverse * currentOrientation))
+        for index in data.indices {
+            data[index].rot = rot
+        }
+        return data
+    }
+
+    /// Head orientation (world-from-head) from a device anchor's transform.
+    private func headOrientation(from anchor: DeviceAnchor) -> simd_quatf {
+        let m = anchor.originFromAnchorTransform
+        return simd_quatf(simd_float3x3(
+            SIMD3<Float>(m.columns.0.x, m.columns.0.y, m.columns.0.z),
+            SIMD3<Float>(m.columns.1.x, m.columns.1.y, m.columns.1.z),
+            SIMD3<Float>(m.columns.2.x, m.columns.2.y, m.columns.2.z)
+        ))
     }
 
     /// Sends the device's real per-eye FOV (radians, OpenXR signed angles) and IPD so the

--- a/clients/Apple/oxrsys-visionos/OXRSys visionOS/Shaders.metal
+++ b/clients/Apple/oxrsys-visionos/OXRSys visionOS/Shaders.metal
@@ -11,9 +11,19 @@
 
 using namespace metal;
 
+// Per-eye asynchronous timewarp. The streamed frame was rendered for the head pose the server
+// reports with it; every vsync we reproject it into the live head pose by rotating each output
+// ray into the render-eye frame and resampling. This keeps the world locked to the head as it
+// rotates (the same idea Quest Link / Virtual Desktop / ALVR use), with no tuning constants —
+// only the eye's real FOV tangents and the rotation between the two head poses.
+struct ReprojData {
+    float3x3 rot;     // maps a current-eye ray direction into render-eye space (R_render^-1 * R_current)
+    float4 tangents;  // (left, right, up, down) positive tangent magnitudes for this eye
+};
+
 struct StereoVertexOut {
     float4 position [[position]];
-    float2 texCoord;
+    float2 texCoord; // output-view screen position in [0,1] for this eye
     float eyeIndex;
 };
 
@@ -41,7 +51,8 @@ vertex StereoVertexOut stereoImmersiveVertex(uint vertexID [[vertex_id]],
 fragment float4 stereoImmersiveFragment(
     StereoVertexOut in [[stage_in]],
     texture2d<float> lumaTexture [[texture(0)]],
-    texture2d<float> chromaTexture [[texture(1)]]
+    texture2d<float> chromaTexture [[texture(1)]],
+    constant ReprojData *reproj [[buffer(0)]]
 ) {
     constexpr sampler textureSampler(address::clamp_to_edge,
                                      mag_filter::linear,
@@ -51,14 +62,39 @@ fragment float4 stereoImmersiveFragment(
         return float4(0.0, 0.0, 0.0, 1.0);
     }
 
-    float eyeOffset = in.eyeIndex * 0.5;
-    float2 stereoUV = float2(in.texCoord.x * 0.5 + eyeOffset, in.texCoord.y);
+    ReprojData rd = reproj[uint(in.eyeIndex)];
+    float left = rd.tangents.x;
+    float right = rd.tangents.y;
+    float up = rd.tangents.z;
+    float down = rd.tangents.w;
 
-    float y = lumaTexture.sample(textureSampler, stereoUV).r;
+    // Ray for this output fragment in the current eye's frustum, at the z = -1 plane.
+    // texCoord.y = 0 is the top of the view (+up), texCoord.y = 1 the bottom (-down).
+    float x = mix(-left, right, in.texCoord.x);
+    float y = mix(up, -down, in.texCoord.y);
+    float3 dirCurrent = float3(x, y, -1.0);
+
+    // Rotate into the pose the server rendered this frame for, then reproject through the same
+    // per-eye frustum to find the source texel. rot == identity → eyeUV == texCoord (exact
+    // passthrough when the head has not moved since the frame was rendered).
+    float3 dirRender = rd.rot * dirCurrent;
+    float2 eyeUV = in.texCoord;
+    if (dirRender.z < 0.0) {
+        float zf = -dirRender.z;
+        float xPlane = dirRender.x / zf;
+        float yPlane = dirRender.y / zf;
+        eyeUV = float2((xPlane + left) / (left + right),
+                       (up - yPlane) / (up + down));
+    }
+
+    float eyeOffset = in.eyeIndex * 0.5;
+    float2 stereoUV = float2(eyeUV.x * 0.5 + eyeOffset, eyeUV.y);
+
+    float yLuma = lumaTexture.sample(textureSampler, stereoUV).r;
     float2 cbcr = chromaTexture.sample(textureSampler, stereoUV).rg - float2(0.5, 0.5);
 
-    float r = y + 1.4020 * cbcr.y;
-    float g = y - 0.3441 * cbcr.x - 0.7141 * cbcr.y;
-    float b = y + 1.7720 * cbcr.x;
+    float r = yLuma + 1.4020 * cbcr.y;
+    float g = yLuma - 0.3441 * cbcr.x - 0.7141 * cbcr.y;
+    float b = yLuma + 1.7720 * cbcr.x;
     return float4(r, g, b, 1.0);
 }

--- a/docs/platforms/visionos.md
+++ b/docs/platforms/visionos.md
@@ -12,6 +12,7 @@ The visionOS target is a first-pass native viewer that fits the Apple platform m
 - a minimal floating control window with a `Search` action
 - UDP stream connection through the shared `OXRSysStreaming` package
 - immersive stereo presentation through a native Metal compositor layer, on a single shared ARKit world-tracking session with a depth-backed drawable so the compositor can reproject
+- world-space (rotational) reprojection of each streamed frame from the runtime's per-frame render pose into the live head pose, so the view stays locked to the world as the head turns
 - automatic immersive VR entry once the stream is connected
 - 6DOF head-pose return while the immersive space is open, including the device's real per-eye FOV and IPD so the runtime renders a matching frustum
 - hand-joint streaming through the shared 26-joint tracking payload

--- a/runtime/src/Session.cpp
+++ b/runtime/src/Session.cpp
@@ -535,7 +535,21 @@ XrResult Session::EndFrame(const XrFrameEndInfo* frameEndInfo)
     if (streamingServer_ && streamingServer_->IsClientConnected())
     {
         auto sendStart = Clock::now();
-        streamingServer_->SendFrame(std::move(frameSource));
+        if (lastRenderHasPose_)
+        {
+            const float renderHeadOrientation[4] = {
+                lastRenderHeadPose_.orientation.x, lastRenderHeadPose_.orientation.y,
+                lastRenderHeadPose_.orientation.z, lastRenderHeadPose_.orientation.w};
+            const float renderHeadPosition[3] = {
+                lastRenderHeadPose_.position.x, lastRenderHeadPose_.position.y,
+                lastRenderHeadPose_.position.z};
+            streamingServer_->SendFrame(std::move(frameSource), renderHeadOrientation,
+                                        renderHeadPosition);
+        }
+        else
+        {
+            streamingServer_->SendFrame(std::move(frameSource));
+        }
         double enqueueMs = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
             Clock::now() - sendStart).count();
 
@@ -724,6 +738,12 @@ XrResult Session::LocateViews(const XrViewLocateInfo* viewLocateInfo, XrViewStat
     }
 
     inputManager_->GetEyeViews(views, 2);
+
+    // Remember the exact head pose this frame is being rendered for, so the streamed frame can be
+    // tagged with it at submission instead of a later re-prediction.
+    lastRenderHeadPose_ = inputManager_->GetHeadPose();
+    lastRenderHasPose_ = true;
+
     return XR_SUCCESS;
 }
 

--- a/runtime/src/Session.h
+++ b/runtime/src/Session.h
@@ -127,6 +127,11 @@ private:
 
     std::unique_ptr<InputManager> inputManager_;
     std::unique_ptr<StreamingServer> streamingServer_;
+
+    // Head pose returned by the most recent xrLocateViews — the exact pose the application renders
+    // the current frame for. Captured here so the streamed frame is tagged with it at submission.
+    XrPosef lastRenderHeadPose_ = {{0, 0, 0, 1}, {0, 0, 0}};
+    bool lastRenderHasPose_ = false;
     std::vector<std::unique_ptr<Swapchain>> swapchains_;
     std::vector<std::unique_ptr<Space>> spaces_;
 

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -2354,7 +2354,9 @@ void StreamingServer::UpdatePredictionHorizon()
     trackingReceiver_->SetPredictionHorizonMs(horizonMs);
 }
 
-void StreamingServer::SendFrame(FrameSource frameSource)
+void StreamingServer::SendFrame(FrameSource frameSource,
+                                const float* renderHeadOrientation,
+                                const float* renderHeadPosition)
 {
     if (!frameSource.IsStereoValid() || state_.load() != State::Connected)
     {
@@ -2377,8 +2379,18 @@ void StreamingServer::SendFrame(FrameSource frameSource)
     frame.valid = true;
     pendingFrameDepthMax_.store(std::max(pendingFrameDepthMax_.load(), 1u));
 
-    // Capture the predicted pose used for this frame's rendering
-    if (trackingReceiver_ != nullptr)
+    // Tag the frame with the exact head pose it was rendered for. The application's render pose
+    // (from xrLocateViews) is preferred so the client reprojects against the pose the pixels were
+    // drawn with; re-predicting here would echo a pose taken later than the one rendered, leaving a
+    // per-frame rotation mismatch that the client cannot correct (head-rotation jitter). Fall back
+    // to the latest predicted pose only when the render pose is unavailable.
+    if (renderHeadOrientation != nullptr && renderHeadPosition != nullptr)
+    {
+        memcpy(frame.headPosition, renderHeadPosition, sizeof(float) * 3);
+        memcpy(frame.headOrientation, renderHeadOrientation, sizeof(float) * 4);
+        frame.hasPose = true;
+    }
+    else if (trackingReceiver_ != nullptr)
     {
         oxr::protocol::TrackingPacket pose = {};
         if (trackingReceiver_->GetPredictedPose(pose))

--- a/runtime/src/StreamingServer.h
+++ b/runtime/src/StreamingServer.h
@@ -61,7 +61,14 @@ public:
     // Queue a rendered frame for asynchronous latest-frame-only encoding.
     // The source owns backend graphics resources until the frame is encoded,
     // dropped, or replaced by a newer pending frame.
-    void SendFrame(FrameSource frameSource);
+    //
+    // renderHeadOrientation (xyzw) / renderHeadPosition (xyz) are the exact head pose the
+    // application rendered this frame for (from xrLocateViews). When provided, the frame is tagged
+    // with it so the headset client reprojects against the pose the pixels were drawn with, instead
+    // of a later re-prediction. Pass nullptr to fall back to the latest predicted pose.
+    void SendFrame(FrameSource frameSource,
+                   const float* renderHeadOrientation = nullptr,
+                   const float* renderHeadPosition = nullptr);
 
     // Set the platform graphics device for VideoEncoder initialization.
     void SetGraphicsContext(const GraphicsContext& graphicsContext) { graphicsContext_ = graphicsContext; }

--- a/runtime/src/TrackingReceiver.cpp
+++ b/runtime/src/TrackingReceiver.cpp
@@ -300,8 +300,10 @@ bool TrackingReceiver::GetPredictedPose(oxr::protocol::TrackingPacket& outPacket
     if (nowNs - lastLogNs >= 5LL * 1000LL * 1000LL * 1000LL &&
         lastPredictionDiagnosticNs_.compare_exchange_strong(lastLogNs, nowNs))
     {
-        spdlog::info("TrackingReceiver: prediction horizon={:.1f}ms head_ang_vel={} speed={:.2f}rad/s",
-                     horizonMs, hasHeadAngularVelocity ? "yes" : "no", headAngularSpeed);
+        spdlog::info("TrackingReceiver: prediction horizon={:.1f}ms head_ang_vel={} speed={:.2f}rad/s "
+                     "reordered_dropped={}",
+                     horizonMs, hasHeadAngularVelocity ? "yes" : "no", headAngularSpeed,
+                     reorderedDropCount_.load());
     }
 
     StoreVec3(outPacket.headPosition,
@@ -377,6 +379,23 @@ void TrackingReceiver::StorePacket(const oxr::protocol::TrackingPacket& packet, 
 
     {
         std::lock_guard<std::mutex> lock(poseMutex_);
+
+        // Drop out-of-order / duplicate tracking packets. UDP reorders packets freely over Wi-Fi,
+        // and the client stamps each sample with a monotonically increasing timestamp. If a packet
+        // arrives with a timestamp at or before the latest stored one, accepting it would put a
+        // backward sample at the head of the history; finite-difference prediction would then read
+        // a reversed delta over a tiny receive-time gap and emit a large bogus angular velocity.
+        // That is the cause of per-frame render-pose jumps (the head-rotation jitter): the runtime
+        // renders the app from a pose that jumps several degrees while the real head moved a
+        // fraction of a degree. Ordering by client timestamp keeps the history strictly forward in
+        // time. Packets without a timestamp (0) cannot be ordered, so they are always accepted.
+        if (hasData_.load() && packet.timestampNs > 0 && latestPacket_.timestampNs > 0 &&
+            packet.timestampNs <= latestPacket_.timestampNs)
+        {
+            reorderedDropCount_.fetch_add(1);
+            return;
+        }
+
         const glm::quat* headReference = nullptr;
         const glm::quat* leftControllerReference = nullptr;
         const glm::quat* rightControllerReference = nullptr;

--- a/runtime/src/TrackingReceiver.h
+++ b/runtime/src/TrackingReceiver.h
@@ -49,6 +49,7 @@ public:
 
     // Stats
     uint64_t GetPacketCount() const { return packetCount_.load(); }
+    uint64_t GetReorderedDropCount() const { return reorderedDropCount_.load(); }
 
 private:
     struct HistorySample
@@ -65,6 +66,7 @@ private:
     std::atomic<bool> running_{false};
     std::atomic<bool> hasData_{false};
     std::atomic<uint64_t> packetCount_{0};
+    std::atomic<uint64_t> reorderedDropCount_{0};
 
     mutable std::mutex poseMutex_;
     oxr::protocol::TrackingPacket latestPacket_ = {};


### PR DESCRIPTION
## Summary

  Makes the Vision Pro stream stay locked to the world during head movement. Two
  matched changes:

  1. **Client world-space reprojection** — each streamed frame is reprojected from
     the pose it was rendered for into the live head pose every vsync, so the view
     tracks the head instead of lagging the stream.
  2. **Runtime render-pose fix** — the runtime now streams the *exact* pose each
     frame was rendered with, so the client reprojects against a pose that matches
     the pixels. This eliminates the head-rotation "ping-pong" jitter.

  They're a pair: the client can only reproject correctly if the render pose it
  receives is the one the frame was actually drawn with. (1) provides the
  mechanism; (2) makes the input to it correct.
  
  ## 1. World-space reprojection (client)
  
  The visionOS viewer now reprojects every presented frame from the runtime's
  per-frame render pose into the current head pose, on a depth-backed drawable so
  the compositor can present it. The view stays world-locked as the head turns
  rather than swimming with stream latency.

  - Reuses the per-frame `VIDEO_FLAG_RENDER_POSE` the runtime already sends.
  - Client-only — no protocol, runtime, or other-client changes.
  - Rotational reprojection (no depth-image transmission), kept intentionally
    simple.
  
  ## 2. Head-rotation jitter fix (runtime)

  **Root cause.** The runtime tagged each streamed frame with a head pose
  *re-predicted at frame submission* (`xrEndFrame`) instead of the pose the
  application had already rendered the frame with at `xrLocateViews`. Submission
  happens a few milliseconds later, after newer tracking has arrived, so the
  echoed pose didn't match the pixels. The client reprojected every frame against
  a slightly wrong orientation. The error was purely rotational — which is why
  head rotation jittered while pure translation stayed seamless, and why no
  client-side reprojection, depth, or prediction tuning could fix it: the mismatch
  was created on the server.
  
  **Fix.**
  - `Session` captures the exact head pose returned by the most recent
    `xrLocateViews` and passes it to `StreamingServer::SendFrame` at `xrEndFrame`.
  - `StreamingServer::SendFrame` tags the frame with that render pose, falling back
    to a predicted pose only when none is supplied. This honors the render-pose
    contract on the server side, matching what the client already does.
  - `TrackingReceiver` drops out-of-order/duplicate UDP tracking packets by the
    client's monotonic timestamp. UDP reorders over Wi-Fi; a late older sample
    would otherwise reach the head of the history and make finite-difference
    prediction emit a bogus angular velocity, compounding the render-pose error.
    Reordered drops are counted and surfaced in the periodic prediction
    diagnostic.
  
  No added latency stages and no tuning constants.

  ## Testing
  
  - Runtime test suite passes (`ctest`, 4/4).
  - visionOS client builds for the visionOS Simulator destination.
  - Validated on hardware: Vision Pro (M5) streaming from a Mac M5 Pro over Wi-Fi.
    Head rotation is stable; translation remains seamless.