### PR TITLE
Honor swapchain subImage rects for side-by-side eye packing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 ### Fixed
 
 - Fixed Metal streaming frame snapshots so the async encoder reads a release-time staging texture instead of a swapchain slot that the app may already have reused.
+- Fixed side-by-side swapchain eye packing by honoring `subImage.imageRect` when compositing each eye for video encode (Unreal Engine and similar clients).
 - Fixed server-side foveated encoding on Metal by running the AADT pass through a compute shader into a private GPU scratch texture before blitting into the VideoToolbox pixel buffer, avoiding render-encoder validation aborts on the first encoded frame.
 - Fixed Quest connection recovery when a server is discovered but no first video frame arrives, returning the client to discovery/retry instead of leaving the standby/loading screen stuck.
 - Fixed controller pose handling so streaming packets only update controller poses when the corresponding controller-active flag is present.

--- a/runtime/src/Session.cpp
+++ b/runtime/src/Session.cpp
@@ -673,6 +673,11 @@ XrResult Session::ValidateProjectionLayer(const XrCompositionLayerProjection& la
         auto* swapchain = Runtime::Get().FromHandle<Swapchain>(reinterpret_cast<uint64_t>(view.subImage.swapchain));
         FrameImageSource imageSource =
             swapchain->GetLastReleasedFrameImageSource(view.subImage.imageArrayIndex);
+        // Honor the per-view sub-rectangle: UE packs both eyes into one swapchain side-by-side.
+        imageSource.sourceX = static_cast<uint32_t>(view.subImage.imageRect.offset.x);
+        imageSource.sourceY = static_cast<uint32_t>(view.subImage.imageRect.offset.y);
+        imageSource.sourceWidth = static_cast<uint32_t>(view.subImage.imageRect.extent.width);
+        imageSource.sourceHeight = static_cast<uint32_t>(view.subImage.imageRect.extent.height);
         if (viewIndex == 0)
         {
             frameSource.left = std::move(imageSource);

--- a/runtime/src/VideoEncoder.h
+++ b/runtime/src/VideoEncoder.h
@@ -106,6 +106,8 @@ private:
         void* tmpLeftTexture = nullptr;   // id<MTLTexture>
         void* tmpRightTexture = nullptr;  // id<MTLTexture>
         void* foveatedScratchTexture = nullptr; // id<MTLTexture>
+        void* leftCropTexture = nullptr;   // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
+        void* rightCropTexture = nullptr;  // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
         bool inUse = false;
     };
 

--- a/runtime/src/VideoEncoder.mm
+++ b/runtime/src/VideoEncoder.mm
@@ -918,6 +918,50 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
         EncodeWaitForFrameImage(cmdBuf, frameSource.right);
     }
 
+    // Crop each eye out of its swapchain sub-rectangle (subImage.imageRect). UE packs both eyes
+    // side-by-side in one swapchain, so without this both eyes would receive the full [L|R] frame.
+    // The crop target is cached per-eye and only reallocated when size/format actually changes
+    // (session start, or a resolution/foveation reconfigure) -- not on every single frame.
+    {
+        id<MTLDevice> cropDev = queue.device;
+        auto cropEye = [&](id<MTLTexture> tex, const FrameImageSource& src, void** cachedTexture) -> id<MTLTexture> {
+            if (tex == nil || !src.HasSourceRect()) return tex;
+            if (src.sourceX == 0 && src.sourceY == 0 &&
+                src.sourceWidth == (uint32_t)tex.width &&
+                src.sourceHeight == (uint32_t)tex.height) return tex;
+
+            id<MTLTexture> eye = (__bridge id<MTLTexture>)*cachedTexture;
+            if (eye == nil || eye.pixelFormat != tex.pixelFormat ||
+                eye.width != (NSUInteger)src.sourceWidth ||
+                eye.height != (NSUInteger)src.sourceHeight)
+            {
+                if (eye != nil)
+                {
+                    [eye release];
+                }
+                MTLTextureDescriptor* d = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:tex.pixelFormat
+                                                                                              width:src.sourceWidth
+                                                                                             height:src.sourceHeight
+                                                                                          mipmapped:NO];
+                d.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
+                d.storageMode = MTLStorageModePrivate;
+                eye = [cropDev newTextureWithDescriptor:d];
+                *cachedTexture = (void*)eye;
+            }
+
+            id<MTLBlitCommandEncoder> cb = [cmdBuf blitCommandEncoder];
+            [cb copyFromTexture:tex sourceSlice:0 sourceLevel:0
+                   sourceOrigin:MTLOriginMake(src.sourceX, src.sourceY, 0)
+                     sourceSize:MTLSizeMake(src.sourceWidth, src.sourceHeight, 1)
+                      toTexture:eye destinationSlice:0 destinationLevel:0
+              destinationOrigin:MTLOriginMake(0, 0, 0)];
+            [cb endEncoding];
+            return eye;
+        };
+        leftTex = cropEye(leftTex, frameSource.left, &slot.leftCropTexture);
+        if (stereo) { rightTex = cropEye(rightTex, frameSource.right, &slot.rightCropTexture); }
+    }
+
     bool forceKeyframe = forceKeyframe_.exchange(false);
     const bool useFoveatedEncoding = stereo &&
         foveationSettings_.enabled &&
@@ -1220,6 +1264,16 @@ void VideoEncoder::DestroySlots()
         {
             [(id<MTLTexture>)slot.foveatedScratchTexture release];
             slot.foveatedScratchTexture = nullptr;
+        }
+        if (slot.leftCropTexture != nullptr)
+        {
+            [(id<MTLTexture>)slot.leftCropTexture release];
+            slot.leftCropTexture = nullptr;
+        }
+        if (slot.rightCropTexture != nullptr)
+        {
+            [(id<MTLTexture>)slot.rightCropTexture release];
+            slot.rightCropTexture = nullptr;
         }
         if (slot.metalTexture != nullptr)
         {


### PR DESCRIPTION
## Summary
- Pass each projection view subImage.imageRect through FrameImageSource into the Metal streaming encoder.
- Crop each eye from side-by-side swapchain layouts before compositing so Unreal Engine and similar clients no longer stream the full frame to both eyes.

## Test plan
- [x] macOS runtime build
- [ ] Stream from Unreal with a side-by-side swapchain and verify left/right eye separation on Quest
- [ ] Regression check with Godot/Unity stereo swapchains (full-texture per eye)

Made with [Cursor](https://cursor.com)