### PR TITLE
Metal streaming: NV12 encode path and per-slot GPU pipelining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 
 - Moved the repository toward the OXRSys cross-platform layout, including `clients/Android/android-vr/`, `clients/Apple/common/`, and `clients/Qt/`.
 - Changed the runtime graphics plumbing to use typed `GraphicsContext` and `FrameSource` data across sessions, swapchains, streaming, and encoders.
+- Changed the macOS Metal streaming encoder to convert composed BGRA frames to NV12 on the GPU before VideoToolbox encode, with per-slot compositing scratch textures and wider compute dispatch groups on Apple Silicon.
 - Kept Vulkan loader usage app-owned: the runtime resolves Vulkan entry points from the application-provided dispatch path or already-loaded process symbols without directly linking or loading the Vulkan loader.
 - Reworked streaming frame submission around a latest-frame-only queue so replacing a pending frame releases its backend resources.
 - Expanded runtime configuration reload behavior for dynamic streaming values while keeping initialization-time resources restart-bound.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 ### Fixed
 
 - Fixed Metal streaming frame snapshots so the async encoder reads a release-time staging texture instead of a swapchain slot that the app may already have reused.
+- Fixed side-by-side swapchain eye packing by honoring `subImage.imageRect` when compositing each eye for video encode (Unreal Engine and similar clients).
 - Fixed server-side foveated encoding on Metal by running the AADT pass through a compute shader into a private GPU scratch texture before blitting into the VideoToolbox pixel buffer, avoiding render-encoder validation aborts on the first encoded frame.
 - Fixed Quest connection recovery when a server is discovered but no first video frame arrives, returning the client to discovery/retry instead of leaving the standby/loading screen stuck.
 - Fixed controller pose handling so streaming packets only update controller poses when the corresponding controller-active flag is present.

--- a/runtime/src/Session.cpp
+++ b/runtime/src/Session.cpp
@@ -673,6 +673,11 @@ XrResult Session::ValidateProjectionLayer(const XrCompositionLayerProjection& la
         auto* swapchain = Runtime::Get().FromHandle<Swapchain>(reinterpret_cast<uint64_t>(view.subImage.swapchain));
         FrameImageSource imageSource =
             swapchain->GetLastReleasedFrameImageSource(view.subImage.imageArrayIndex);
+        // Honor the per-view sub-rectangle: UE packs both eyes into one swapchain side-by-side.
+        imageSource.sourceX = static_cast<uint32_t>(view.subImage.imageRect.offset.x);
+        imageSource.sourceY = static_cast<uint32_t>(view.subImage.imageRect.offset.y);
+        imageSource.sourceWidth = static_cast<uint32_t>(view.subImage.imageRect.extent.width);
+        imageSource.sourceHeight = static_cast<uint32_t>(view.subImage.imageRect.extent.height);
         if (viewIndex == 0)
         {
             frameSource.left = std::move(imageSource);

--- a/runtime/src/VideoEncoder.h
+++ b/runtime/src/VideoEncoder.h
@@ -101,11 +101,17 @@ public:
 private:
     struct BufferSlot
     {
-        void* pixelBuffer = nullptr;      // CVPixelBufferRef
-        void* metalTexture = nullptr;     // CVMetalTextureRef
-        void* tmpLeftTexture = nullptr;   // id<MTLTexture>
-        void* tmpRightTexture = nullptr;  // id<MTLTexture>
-        void* foveatedScratchTexture = nullptr; // id<MTLTexture>
+        void* pixelBuffer = nullptr;   // CVPixelBufferRef (NV12 biplanar)
+        void* lumaTexture = nullptr;   // CVMetalTextureRef, plane 0 (R8Unorm)
+        void* chromaTexture = nullptr; // CVMetalTextureRef, plane 1 (RG8Unorm)
+        // Per-slot scratch (not shared): a shared scratch texture forces Metal's
+        // hazard tracking to fully serialize each frame's GPU compute against the
+        // previous frame's, defeating the slot pool's whole point (overlapping
+        // GPU work across in-flight frames). Costs ~10MB/slot on unified memory,
+        // buys back real pipelining.
+        void* composeTexture = nullptr;    // id<MTLTexture>, BGRA private, width_ x height_
+        void* tmpLeftTexture = nullptr;    // id<MTLTexture>, BGRA private, eyeWidth_ x height_
+        void* tmpRightTexture = nullptr;   // id<MTLTexture>, BGRA private, eyeWidth_ x height_
         void* leftCropTexture = nullptr;   // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
         void* rightCropTexture = nullptr;  // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
         bool inUse = false;
@@ -128,6 +134,7 @@ private:
         void* scaler = nullptr;           // MPSImageBilinearScale*
         void* foveationPipeline = nullptr; // id<MTLComputePipelineState>
         void* foveationSampler = nullptr;  // id<MTLSamplerState>
+        void* nv12Pipeline = nullptr;      // id<MTLComputePipelineState>, BGRA -> NV12
     };
 
     struct FfmpegState
@@ -158,6 +165,8 @@ private:
     std::atomic<uint32_t> inFlightFrameCount_{0};
     std::atomic<uint64_t> frameNumberCounter_{0};
     std::mutex slotMutex_;
-    static constexpr size_t SlotCount = 3;
+    // 5 slots gives VideoToolbox more in-flight headroom on Apple Silicon (M4 Max
+    // class GPUs) before frames are dropped under transient encode latency spikes.
+    static constexpr size_t SlotCount = 5;
     std::array<BufferSlot, SlotCount> slots_{};
 };

--- a/runtime/src/VideoEncoder.h
+++ b/runtime/src/VideoEncoder.h
@@ -106,6 +106,8 @@ private:
         void* tmpLeftTexture = nullptr;   // id<MTLTexture>
         void* tmpRightTexture = nullptr;  // id<MTLTexture>
         void* foveatedScratchTexture = nullptr; // id<MTLTexture>
+        void* leftCropTexture = nullptr;   // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
+        void* rightCropTexture = nullptr;  // id<MTLTexture>, lazily (re)sized to sourceWidth/sourceHeight
         bool inUse = false;
     };
 

--- a/runtime/src/VideoEncoder.mm
+++ b/runtime/src/VideoEncoder.mm
@@ -918,6 +918,50 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
         EncodeWaitForFrameImage(cmdBuf, frameSource.right);
     }
 
+    // Crop each eye out of its swapchain sub-rectangle (subImage.imageRect). UE packs both eyes
+    // side-by-side in one swapchain, so without this both eyes would receive the full [L|R] frame.
+    // The crop target is cached per-eye and only reallocated when size/format actually changes
+    // (session start, or a resolution/foveation reconfigure) -- not on every single frame.
+    {
+        id<MTLDevice> cropDev = queue.device;
+        auto cropEye = [&](id<MTLTexture> tex, const FrameImageSource& src, void** cachedTexture) -> id<MTLTexture> {
+            if (tex == nil || !src.HasSourceRect()) return tex;
+            if (src.sourceX == 0 && src.sourceY == 0 &&
+                src.sourceWidth == (uint32_t)tex.width &&
+                src.sourceHeight == (uint32_t)tex.height) return tex;
+
+            id<MTLTexture> eye = (__bridge id<MTLTexture>)*cachedTexture;
+            if (eye == nil || eye.pixelFormat != tex.pixelFormat ||
+                eye.width != (NSUInteger)src.sourceWidth ||
+                eye.height != (NSUInteger)src.sourceHeight)
+            {
+                if (eye != nil)
+                {
+                    [eye release];
+                }
+                MTLTextureDescriptor* d = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:tex.pixelFormat
+                                                                                              width:src.sourceWidth
+                                                                                             height:src.sourceHeight
+                                                                                          mipmapped:NO];
+                d.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
+                d.storageMode = MTLStorageModePrivate;
+                eye = [cropDev newTextureWithDescriptor:d];
+                *cachedTexture = (void*)eye;
+            }
+
+            id<MTLBlitCommandEncoder> cb = [cmdBuf blitCommandEncoder];
+            [cb copyFromTexture:tex sourceSlice:0 sourceLevel:0
+                   sourceOrigin:MTLOriginMake(src.sourceX, src.sourceY, 0)
+                     sourceSize:MTLSizeMake(src.sourceWidth, src.sourceHeight, 1)
+                      toTexture:eye destinationSlice:0 destinationLevel:0
+              destinationOrigin:MTLOriginMake(0, 0, 0)];
+            [cb endEncoding];
+            return eye;
+        };
+        leftTex = cropEye(leftTex, frameSource.left, &slot.leftCropTexture);
+        if (stereo) { rightTex = cropEye(rightTex, frameSource.right, &slot.rightCropTexture); }
+    }
+
     bool forceKeyframe = forceKeyframe_.exchange(false);
     const bool useFoveatedEncoding = stereo &&
         foveationSettings_.enabled &&
@@ -1220,6 +1264,16 @@ void VideoEncoder::DestroySlots()
         {
             [(id<MTLTexture>)slot.foveatedScratchTexture release];
             slot.foveatedScratchTexture = nullptr;
+        }
+        if (slot.leftCropTexture != nullptr)
+        {
+            [(id<MTLTexture>)slot.leftCropTexture release];
+            slot.leftCropTexture = nullptr;
+        }
+        if (slot.rightCropTexture != nullptr)
+        {
+            [(id<MTLTexture>)slot.rightCropTexture release];
+            slot.rightCropTexture = nullptr;
         }
         if (slot.metalTexture != nullptr)
         {

--- a/runtime/src/VideoEncoder.mm
+++ b/runtime/src/VideoEncoder.mm
@@ -122,6 +122,53 @@ kernel void foveation_kernel(texture2d<float, access::sample> leftTexture [[text
 }
 )METAL";
 
+// BGRA -> biplanar NV12 (BT.709 full range) so the encoder's CVPixelBufferPool
+// can hand VideoToolbox chroma-subsampled YCbCr directly instead of forcing an
+// internal RGB->YUV conversion of a 2x-larger BGRA buffer on every frame.
+constexpr const char* kNv12ConversionMetalSource = R"METAL(
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void bgra_to_nv12(texture2d<float, access::read> src [[texture(0)]],
+                         texture2d<float, access::write> outY [[texture(1)]],
+                         texture2d<float, access::write> outCbCr [[texture(2)]],
+                         uint2 gid [[thread_position_in_grid]])
+{
+    uint srcW = src.get_width();
+    uint srcH = src.get_height();
+    uint2 base = gid * 2;
+    if (base.x >= srcW || base.y >= srcH)
+    {
+        return;
+    }
+
+    const float3 kBt709 = float3(0.2126, 0.7152, 0.0722);
+    float3 sum = float3(0.0);
+    uint count = 0;
+    for (uint dy = 0; dy < 2; ++dy)
+    {
+        for (uint dx = 0; dx < 2; ++dx)
+        {
+            uint2 c = base + uint2(dx, dy);
+            if (c.x >= srcW || c.y >= srcH)
+            {
+                continue;
+            }
+            float3 rgb = src.read(c).rgb;
+            outY.write(float4(dot(rgb, kBt709), 0.0, 0.0, 1.0), c);
+            sum += rgb;
+            count += 1;
+        }
+    }
+
+    float3 avg = sum / max((float)count, 1.0);
+    float yAvg = dot(avg, kBt709);
+    float cb = (avg.b - yAvg) * (0.5 / (1.0 - kBt709.b)) + 0.5;
+    float cr = (avg.r - yAvg) * (0.5 / (1.0 - kBt709.r)) + 0.5;
+    outCbCr.write(float4(cb, cr, 0.0, 1.0), gid);
+}
+)METAL";
+
 void FinalizeEncodeFrame(EncodeFrameContext* context, bool frameDropped)
 {
     if (context == nullptr)
@@ -379,22 +426,23 @@ bool TextureAllowsUsage(id<MTLTexture> texture, MTLTextureUsage requiredUsage)
            (declaredUsage & requiredUsage) == requiredUsage;
 }
 
-id<MTLComputePipelineState> CreateFoveationPipeline(id<MTLDevice> device)
+id<MTLComputePipelineState> CreateComputePipeline(id<MTLDevice> device, const char* source,
+                                                   const char* entryPoint, const char* debugLabel)
 {
     NSError* error = nil;
-    NSString* source = [NSString stringWithUTF8String:kFoveationMetalSource];
-    id<MTLLibrary> library = [device newLibraryWithSource:source options:nil error:&error];
+    NSString* nsSource = [NSString stringWithUTF8String:source];
+    id<MTLLibrary> library = [device newLibraryWithSource:nsSource options:nil error:&error];
     if (library == nil)
     {
-        spdlog::error("VideoEncoder: Failed to compile foveation shader: {}",
+        spdlog::error("VideoEncoder: Failed to compile {} shader: {}", debugLabel,
                       error != nil ? error.localizedDescription.UTF8String : "unknown error");
         return nil;
     }
 
-    id<MTLFunction> kernelFunction = [library newFunctionWithName:@"foveation_kernel"];
+    id<MTLFunction> kernelFunction = [library newFunctionWithName:[NSString stringWithUTF8String:entryPoint]];
     if (kernelFunction == nil)
     {
-        spdlog::error("VideoEncoder: Failed to load foveation compute shader entry point");
+        spdlog::error("VideoEncoder: Failed to load {} compute shader entry point", debugLabel);
         [library release];
         return nil;
     }
@@ -404,13 +452,41 @@ id<MTLComputePipelineState> CreateFoveationPipeline(id<MTLDevice> device)
         [device newComputePipelineStateWithFunction:kernelFunction error:&error];
     if (pipeline == nil)
     {
-        spdlog::error("VideoEncoder: Failed to create foveation compute pipeline: {}",
+        spdlog::error("VideoEncoder: Failed to create {} compute pipeline: {}", debugLabel,
                       error != nil ? error.localizedDescription.UTF8String : "unknown error");
     }
 
     [kernelFunction release];
     [library release];
     return pipeline;
+}
+
+id<MTLComputePipelineState> CreateFoveationPipeline(id<MTLDevice> device)
+{
+    return CreateComputePipeline(device, kFoveationMetalSource, "foveation_kernel", "foveation");
+}
+
+id<MTLComputePipelineState> CreateNv12ConversionPipeline(id<MTLDevice> device)
+{
+    return CreateComputePipeline(device, kNv12ConversionMetalSource, "bgra_to_nv12", "NV12 conversion");
+}
+
+// Dispatch sizing shared by both compute kernels: don't artificially cap the
+// threadgroup width at 16 -- Apple Silicon GPUs (M1 through M4) report a
+// threadExecutionWidth of 32, so capping at 16 wastes half the SIMD group on
+// every dispatch.
+void DispatchCompute2D(id<MTLComputeCommandEncoder> encoder, id<MTLComputePipelineState> pipeline,
+                        uint32_t width, uint32_t height)
+{
+    const NSUInteger threadsX = std::max<NSUInteger>(1, pipeline.threadExecutionWidth);
+    const NSUInteger threadsY = std::max<NSUInteger>(
+        1, pipeline.maxTotalThreadsPerThreadgroup / threadsX);
+    const MTLSize threadsPerGroup = MTLSizeMake(threadsX, threadsY, 1);
+    const MTLSize threadgroups = MTLSizeMake(
+        ((NSUInteger)width + threadsX - 1) / threadsX,
+        ((NSUInteger)height + threadsY - 1) / threadsY,
+        1);
+    [encoder dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerGroup];
 }
 
 id<MTLSamplerState> CreateLinearClampSampler(id<MTLDevice> device)
@@ -537,6 +613,14 @@ bool VideoEncoder::Initialize(uint32_t width, uint32_t height, uint32_t fps,
         }
     }
 
+    videoToolbox_.nv12Pipeline = (void*)CreateNv12ConversionPipeline(device);
+    if (videoToolbox_.nv12Pipeline == nullptr)
+    {
+        spdlog::error("VideoEncoder: BGRA->NV12 conversion shader is unavailable");
+        Shutdown();
+        return false;
+    }
+
     CVMetalTextureCacheRef cache = nullptr;
     CVReturn cvResult = CVMetalTextureCacheCreate(
         kCFAllocatorDefault, nullptr, device, nullptr, &cache);
@@ -550,12 +634,18 @@ bool VideoEncoder::Initialize(uint32_t width, uint32_t height, uint32_t fps,
     NSDictionary* poolConfig = @{
         (NSString*)kCVPixelBufferPoolMinimumBufferCountKey: @(SlotCount),
     };
+    // Biplanar 4:2:0 NV12, full range, BT.709. This is what the HEVC hardware
+    // encoder consumes natively -- handing it BGRA forces VideoToolbox to do its
+    // own RGB->YUV conversion internally on a buffer twice the size.
     NSDictionary* poolAttrs = @{
         (NSString*)kCVPixelBufferWidthKey: @(width),
         (NSString*)kCVPixelBufferHeightKey: @(height),
-        (NSString*)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+        (NSString*)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange),
         (NSString*)kCVPixelBufferIOSurfacePropertiesKey: @{},
         (NSString*)kCVPixelBufferMetalCompatibilityKey: @YES,
+        (NSString*)kCVImageBufferColorPrimariesKey: (NSString*)kCVImageBufferColorPrimaries_ITU_R_709_2,
+        (NSString*)kCVImageBufferTransferFunctionKey: (NSString*)kCVImageBufferTransferFunction_ITU_R_709_2,
+        (NSString*)kCVImageBufferYCbCrMatrixKey: (NSString*)kCVImageBufferYCbCrMatrix_ITU_R_709_2,
     };
 
     CVPixelBufferPoolRef pool = nullptr;
@@ -580,17 +670,16 @@ bool VideoEncoder::Initialize(uint32_t width, uint32_t height, uint32_t fps,
     tmpDesc.usage = MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
     tmpDesc.storageMode = MTLStorageModePrivate;
 
-    MTLTextureDescriptor* foveatedScratchDesc = nil;
-    if (foveationSettings_.enabled)
-    {
-        foveatedScratchDesc = [MTLTextureDescriptor
-            texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                         width:MAX((uint32_t)1, width_)
-                                        height:MAX((uint32_t)1, height_)
-                                     mipmapped:NO];
-        foveatedScratchDesc.usage = MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
-        foveatedScratchDesc.storageMode = MTLStorageModePrivate;
-    }
+    MTLTextureDescriptor* composeDesc = [MTLTextureDescriptor
+        texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                     width:MAX((uint32_t)1, width_)
+                                    height:MAX((uint32_t)1, height_)
+                                 mipmapped:NO];
+    composeDesc.usage = MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite | MTLTextureUsageRenderTarget;
+    composeDesc.storageMode = MTLStorageModePrivate;
+
+    const uint32_t chromaWidth = MAX((uint32_t)1, (width_ + 1) / 2);
+    const uint32_t chromaHeight = MAX((uint32_t)1, (height_ + 1) / 2);
 
     for (size_t i = 0; i < SlotCount; i++)
     {
@@ -604,40 +693,66 @@ bool VideoEncoder::Initialize(uint32_t width, uint32_t height, uint32_t fps,
             return false;
         }
 
-        CVMetalTextureRef cvMetalTexture = nullptr;
+        CVMetalTextureRef lumaTexture = nullptr;
         cvResult = CVMetalTextureCacheCreateTextureFromImage(
             kCFAllocatorDefault,
             (CVMetalTextureCacheRef)videoToolbox_.textureCache,
             pixelBuffer,
             nullptr,
-            MTLPixelFormatBGRA8Unorm,
+            MTLPixelFormatR8Unorm,
             width_,
             height_,
-            0,
-            &cvMetalTexture);
-        if (cvResult != kCVReturnSuccess || cvMetalTexture == nullptr)
+            0, // luma plane
+            &lumaTexture);
+        if (cvResult != kCVReturnSuccess || lumaTexture == nullptr)
         {
-            spdlog::error("VideoEncoder: Failed to create Metal texture for slot {}", i);
+            spdlog::error("VideoEncoder: Failed to create luma plane texture for slot {}", i);
+            CVPixelBufferRelease(pixelBuffer);
+            Shutdown();
+            return false;
+        }
+
+        CVMetalTextureRef chromaTexture = nullptr;
+        cvResult = CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault,
+            (CVMetalTextureCacheRef)videoToolbox_.textureCache,
+            pixelBuffer,
+            nullptr,
+            MTLPixelFormatRG8Unorm,
+            chromaWidth,
+            chromaHeight,
+            1, // chroma plane
+            &chromaTexture);
+        if (cvResult != kCVReturnSuccess || chromaTexture == nullptr)
+        {
+            spdlog::error("VideoEncoder: Failed to create chroma plane texture for slot {}", i);
+            CFRelease(lumaTexture);
+            CVPixelBufferRelease(pixelBuffer);
+            Shutdown();
+            return false;
+        }
+
+        id<MTLTexture> composeTexture = [device newTextureWithDescriptor:composeDesc];
+        id<MTLTexture> tmpLeftTexture = [device newTextureWithDescriptor:tmpDesc];
+        id<MTLTexture> tmpRightTexture = [device newTextureWithDescriptor:tmpDesc];
+        if (composeTexture == nil || tmpLeftTexture == nil || tmpRightTexture == nil)
+        {
+            spdlog::error("VideoEncoder: Failed to create compositing scratch textures for slot {}", i);
+            CFRelease(lumaTexture);
+            CFRelease(chromaTexture);
             CVPixelBufferRelease(pixelBuffer);
             Shutdown();
             return false;
         }
 
         slots_[i].pixelBuffer = pixelBuffer;
-        slots_[i].metalTexture = cvMetalTexture;
-        slots_[i].tmpLeftTexture = (void*)[device newTextureWithDescriptor:tmpDesc];
-        slots_[i].tmpRightTexture = (void*)[device newTextureWithDescriptor:tmpDesc];
-        if (foveatedScratchDesc != nil)
-        {
-            slots_[i].foveatedScratchTexture =
-                (void*)[device newTextureWithDescriptor:foveatedScratchDesc];
-            if (slots_[i].foveatedScratchTexture == nullptr)
-            {
-                spdlog::error("VideoEncoder: Failed to create foveated compute scratch texture for slot {}", i);
-                Shutdown();
-                return false;
-            }
-        }
+        slots_[i].lumaTexture = lumaTexture;
+        slots_[i].chromaTexture = chromaTexture;
+        slots_[i].composeTexture = (void*)composeTexture;
+        slots_[i].tmpLeftTexture = (void*)tmpLeftTexture;
+        slots_[i].tmpRightTexture = (void*)tmpRightTexture;
+        // leftCropTexture/rightCropTexture: lazily (re)allocated in EncodeInternal
+        // once the swapchain sub-rect (srcW/srcH) is known.
         slots_[i].inUse = false;
     }
 
@@ -669,6 +784,14 @@ bool VideoEncoder::Initialize(uint32_t width, uint32_t height, uint32_t fps,
         kVTCompressionPropertyKey_RealTime, kCFBooleanTrue);
     VTSessionSetProperty(compressionSession,
         kVTCompressionPropertyKey_AllowFrameReordering, kCFBooleanFalse);
+    // Must match the NV12 pixel buffer pool's color attributes (set above) so
+    // VideoToolbox tags the bitstream with the same primaries/matrix it encoded.
+    VTSessionSetProperty(compressionSession,
+        kVTCompressionPropertyKey_ColorPrimaries, kCVImageBufferColorPrimaries_ITU_R_709_2);
+    VTSessionSetProperty(compressionSession,
+        kVTCompressionPropertyKey_TransferFunction, kCVImageBufferTransferFunction_ITU_R_709_2);
+    VTSessionSetProperty(compressionSession,
+        kVTCompressionPropertyKey_YCbCrMatrix, kCVImageBufferYCbCrMatrix_ITU_R_709_2);
 
     // Define one deterministic SDR color contract for every encoded stream. VideoToolbox embeds
     // these values in H.264/H.265 metadata and uses the matching matrix for RGB-to-YCbCr conversion.
@@ -800,6 +923,11 @@ void VideoEncoder::Shutdown()
         [(id<MTLSamplerState>)videoToolbox_.foveationSampler release];
         videoToolbox_.foveationSampler = nullptr;
     }
+    if (videoToolbox_.nv12Pipeline != nullptr)
+    {
+        [(id<MTLComputePipelineState>)videoToolbox_.nv12Pipeline release];
+        videoToolbox_.nv12Pipeline = nullptr;
+    }
     if (videoToolbox_.commandQueue != nullptr)
     {
         [(id<MTLCommandQueue>)videoToolbox_.commandQueue release];
@@ -867,9 +995,13 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
 
     BufferSlot& slot = slots_[slotIndex];
     CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)slot.pixelBuffer;
-    CVMetalTextureRef cvMetalTexture = (CVMetalTextureRef)slot.metalTexture;
-    id<MTLTexture> dstTexture = CVMetalTextureGetTexture(cvMetalTexture);
-    if (pixelBuffer == nullptr || cvMetalTexture == nullptr || dstTexture == nil)
+    CVMetalTextureRef cvLumaTexture = (CVMetalTextureRef)slot.lumaTexture;
+    CVMetalTextureRef cvChromaTexture = (CVMetalTextureRef)slot.chromaTexture;
+    id<MTLTexture> lumaTexture = CVMetalTextureGetTexture(cvLumaTexture);
+    id<MTLTexture> chromaTexture = CVMetalTextureGetTexture(cvChromaTexture);
+    id<MTLTexture> dstTexture = (id<MTLTexture>)slot.composeTexture;
+    if (pixelBuffer == nullptr || cvLumaTexture == nullptr || cvChromaTexture == nullptr ||
+        lumaTexture == nil || chromaTexture == nil || dstTexture == nil)
     {
         ReleaseSlot(slotIndex);
         return false;
@@ -967,7 +1099,7 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
         foveationSettings_.enabled &&
         videoToolbox_.foveationPipeline != nullptr &&
         videoToolbox_.foveationSampler != nullptr &&
-        slot.foveatedScratchTexture != nullptr;
+        slot.composeTexture != nullptr;
     bool needsDownscale = stereo
         ? (leftTex.width != (NSUInteger)eyeWidth_ || leftTex.height != (NSUInteger)height_ ||
            rightTex.width != (NSUInteger)eyeWidth_ || rightTex.height != (NSUInteger)height_)
@@ -996,7 +1128,10 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
 
     if (useFoveatedEncoding)
     {
-        id<MTLTexture> foveatedDstTexture = (id<MTLTexture>)slot.foveatedScratchTexture;
+        // Foveation kernel writes straight into the shared compose texture --
+        // no separate scratch + blit needed since dstTexture *is* the kernel's
+        // output target here.
+        id<MTLTexture> foveatedDstTexture = dstTexture;
         if (foveatedDstTexture == nil ||
             foveatedDstTexture.width != (NSUInteger)width_ ||
             foveatedDstTexture.height != (NSUInteger)height_ ||
@@ -1035,34 +1170,8 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
         [computeEncoder setSamplerState:(id<MTLSamplerState>)videoToolbox_.foveationSampler
                                 atIndex:0];
         [computeEncoder setBytes:&uniforms length:sizeof(uniforms) atIndex:0];
-
-        const NSUInteger threadsX = std::max<NSUInteger>(1, std::min<NSUInteger>(pipeline.threadExecutionWidth, 16));
-        const NSUInteger threadsY = std::max<NSUInteger>(
-            1,
-            std::min<NSUInteger>(pipeline.maxTotalThreadsPerThreadgroup / threadsX, 16));
-        const MTLSize threadsPerGroup = MTLSizeMake(threadsX, threadsY, 1);
-        const MTLSize threadgroups = MTLSizeMake(
-            ((NSUInteger)width_ + threadsX - 1) / threadsX,
-            ((NSUInteger)height_ + threadsY - 1) / threadsY,
-            1);
-        [computeEncoder dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerGroup];
+        DispatchCompute2D(computeEncoder, pipeline, width_, height_);
         [computeEncoder endEncoding];
-
-        id<MTLBlitCommandEncoder> blit = [cmdBuf blitCommandEncoder];
-        if (blit == nil)
-        {
-            return dropAcquiredSlot("failed to create foveated blit encoder");
-        }
-        [blit copyFromTexture:foveatedDstTexture
-                  sourceSlice:0
-                  sourceLevel:0
-                 sourceOrigin:MTLOriginMake(0, 0, 0)
-                   sourceSize:MTLSizeMake(width_, height_, 1)
-                    toTexture:dstTexture
-             destinationSlice:0
-             destinationLevel:0
-            destinationOrigin:MTLOriginMake(0, 0, 0)];
-        [blit endEncoding];
     }
     else if (stereo && needsDownscale)
     {
@@ -1141,6 +1250,25 @@ bool VideoEncoder::EncodeInternal(FrameSource frameSource, bool stereo,
              destinationLevel:0
             destinationOrigin:MTLOriginMake(0, 0, 0)];
         [blit endEncoding];
+    }
+
+    // Convert the composed BGRA frame to the NV12 biplanar buffer VideoToolbox
+    // actually wants, instead of feeding it BGRA and forcing an internal RGB->YUV
+    // conversion of a buffer twice the size on every encode.
+    {
+        id<MTLComputeCommandEncoder> nv12Encoder = [cmdBuf computeCommandEncoder];
+        if (nv12Encoder == nil)
+        {
+            return dropAcquiredSlot("failed to create NV12 conversion compute encoder");
+        }
+        id<MTLComputePipelineState> nv12Pipeline =
+            (id<MTLComputePipelineState>)videoToolbox_.nv12Pipeline;
+        [nv12Encoder setComputePipelineState:nv12Pipeline];
+        [nv12Encoder setTexture:dstTexture atIndex:0];
+        [nv12Encoder setTexture:lumaTexture atIndex:1];
+        [nv12Encoder setTexture:chromaTexture atIndex:2];
+        DispatchCompute2D(nv12Encoder, nv12Pipeline, (uint32_t)chromaTexture.width, (uint32_t)chromaTexture.height);
+        [nv12Encoder endEncoding];
     }
 
     auto* context = new EncodeFrameContext();
@@ -1250,6 +1378,21 @@ void VideoEncoder::DestroySlots()
     {
         slot.inUse = false;
 
+        if (slot.lumaTexture != nullptr)
+        {
+            CFRelease(slot.lumaTexture);
+            slot.lumaTexture = nullptr;
+        }
+        if (slot.chromaTexture != nullptr)
+        {
+            CFRelease(slot.chromaTexture);
+            slot.chromaTexture = nullptr;
+        }
+        if (slot.composeTexture != nullptr)
+        {
+            [(id<MTLTexture>)slot.composeTexture release];
+            slot.composeTexture = nullptr;
+        }
         if (slot.tmpLeftTexture != nullptr)
         {
             [(id<MTLTexture>)slot.tmpLeftTexture release];
@@ -1260,11 +1403,6 @@ void VideoEncoder::DestroySlots()
             [(id<MTLTexture>)slot.tmpRightTexture release];
             slot.tmpRightTexture = nullptr;
         }
-        if (slot.foveatedScratchTexture != nullptr)
-        {
-            [(id<MTLTexture>)slot.foveatedScratchTexture release];
-            slot.foveatedScratchTexture = nullptr;
-        }
         if (slot.leftCropTexture != nullptr)
         {
             [(id<MTLTexture>)slot.leftCropTexture release];
@@ -1274,11 +1412,6 @@ void VideoEncoder::DestroySlots()
         {
             [(id<MTLTexture>)slot.rightCropTexture release];
             slot.rightCropTexture = nullptr;
-        }
-        if (slot.metalTexture != nullptr)
-        {
-            CFRelease(slot.metalTexture);
-            slot.metalTexture = nullptr;
         }
         if (slot.pixelBuffer != nullptr)
         {


### PR DESCRIPTION
## Summary
- Convert composed BGRA frames to biplanar NV12 on the GPU before VideoToolbox encode.
- Use per-slot compositing scratch textures so in-flight encode work can overlap instead of serializing on a shared scratch texture.
- Widen compute dispatch groups to Apple Silicon SIMD width and expand the encoder slot pool for transient encode latency headroom.

Stacks on #12 (subImage rect cropping). Merge #12 first.

## Test plan
- [x] macOS runtime build
- [x] USB Quest streaming at 72/90 Hz with ABR enabled
- [x] Compare encode latency and dropped-frame counts against the previous BGRA pixel-buffer path

Made with [Cursor](https://cursor.com)