### PR TITLE
Fix streaming ABR false constraints at high refresh and transport baselines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Updated the Quest MediaCodec input sizing to keep bounded headroom for high-bitrate foveated-encoding IDR frames.
 - Updated the Quest/PICO shell to pause passthrough, stop local shell interactions, and release shell GL resources while streaming video is actively rendered.
 - Updated SwiftUI Home and Qt Home with ABR and Quest client reprojection controls plus runtime status display for frame age, ABR state, and reprojection reuse.
+- Updated the streaming ABR controller to scale reprojection thresholds by negotiated refresh rate, raise USB/pose-reprojection baselines, and probe upward when bitrate is stuck at the floor for non-bandwidth causes.
 - Updated FFmpeg encoder preset mapping so Linux scaffolding maps `speed`, `balanced`, and `quality` to low-latency FFmpeg presets instead of always using `ultrafast`.
 - Updated macOS Home for direct distribution workflows, selected-runtime app launching, runtime registration, package-compatible runtime paths, runtime activity display, and shared Developer simulator integration.
 - Updated visionOS streaming behavior around the minimal search window, automatic immersive entry on stream connection, head/hand tracking, and first-pass tracked accessory controller data.

--- a/runtime/src/StreamingAbr.h
+++ b/runtime/src/StreamingAbr.h
@@ -91,7 +91,8 @@ class Controller
 public:
     void Reset(Mode mode, uint32_t currentBitrateMbps, uint32_t maxBitrateMbps,
                float configuredResolutionScale = 1.0f,
-               float minimumResolutionScale = 0.5f)
+               float minimumResolutionScale = 0.5f,
+               uint32_t refreshRateHz = 72u)
     {
         mode_ = mode;
         maxBitrateMbps_ = std::max(maxBitrateMbps, kMinBitrateMbps);
@@ -101,8 +102,17 @@ public:
         state_ = State::Stable;
         stableWindows_ = 0;
         minimumProfileHoldWindows_ = 0;
+        floorStuckWindows_ = 0;
         profile_ = "balanced";
         samples_.clear();
+        // reprojectedFramesDelta/staleFrameReusesDelta are counted over a fixed
+        // wall-clock reporting interval, not per-frame -- at a higher refresh
+        // rate, strictly more frames execute in that same interval, so the same
+        // *proportional* smoothness produces a higher *absolute* count. The
+        // thresholds below were calibrated against a 72Hz baseline; scale
+        // incoming counts back to that baseline so 90Hz+ doesn't get flagged
+        // as constrained for behaving identically well at a higher frame rate.
+        refreshScale_ = 72.0f / std::max(1.0f, static_cast<float>(refreshRateHz));
     }
 
     Decision Update(const Sample& sample)
@@ -132,20 +142,22 @@ public:
         const float averageFrameAgeMs = Average([](const Sample& item) {
             return item.displayedFrameAgeMs;
         });
-        const float averageReprojectedFrames = Average([](const Sample& item) {
-            return static_cast<float>(item.reprojectedFramesDelta);
+        const float averageReprojectedFrames = Average([this](const Sample& item) {
+            return static_cast<float>(item.reprojectedFramesDelta) * refreshScale_;
         });
-        const float averageStaleReuses = Average([](const Sample& item) {
-            return static_cast<float>(item.staleFrameReusesDelta);
+        const float averageStaleReuses = Average([this](const Sample& item) {
+            return static_cast<float>(item.staleFrameReusesDelta) * refreshScale_;
         });
+        const float scaledReprojectedFrames = static_cast<float>(sample.reprojectedFramesDelta) * refreshScale_;
+        const float scaledStaleReuses = static_cast<float>(sample.staleFrameReusesDelta) * refreshScale_;
 
         const bool immediateRecovery =
             sample.keyframeRequestsDelta > 0 ||
             sample.videoSendDroppedFramesDelta > 1 ||
             sample.encoderDroppedFramesDelta > 0 ||
             sample.displayedFrameAgeMs >= kRecoveryFrameAgeMs ||
-            sample.reprojectedFramesDelta >= kRecoveryReprojectedFrames ||
-            sample.staleFrameReusesDelta >= kRecoveryStaleReuses;
+            scaledReprojectedFrames >= static_cast<float>(kRecoveryReprojectedFrames) ||
+            scaledStaleReuses >= static_cast<float>(kRecoveryStaleReuses);
         const bool constrained =
             immediateRecovery ||
             averageLatencyMs >= kConstrainedLatencyMs ||
@@ -163,9 +175,32 @@ public:
             const uint32_t numerator = state_ == State::Recovery ? 80u : 90u;
             nextBitrate = std::max(currentBitrateMbps_ * numerator / 100u, kMinBitrateMbps);
             minimumProfileHoldWindows_ = std::max(minimumProfileHoldWindows_, kMinimumProfileHoldWindows);
+
+            // Cutting bitrate only helps if bitrate is actually the cause of the
+            // constraint (reproj/staleness/latency). If something else is the real
+            // cause -- GPU scheduling jitter, not bandwidth -- repeatedly halving
+            // bitrate never fixes it, and once at the floor the controller has no
+            // way back: Stable requires the very metrics this state can't improve.
+            // Cutting is a one-way ratchet without this escape valve. After sitting
+            // at the floor a while with no improvement, periodically probe upward
+            // to test whether bitrate was ever the actual constraint.
+            if (currentBitrateMbps_ <= kMinBitrateMbps)
+            {
+                floorStuckWindows_++;
+                if (floorStuckWindows_ >= kFloorProbeWindows)
+                {
+                    nextBitrate = std::min(kMinBitrateMbps * 3u, maxBitrateMbps_);
+                    floorStuckWindows_ = 0;
+                }
+            }
+            else
+            {
+                floorStuckWindows_ = 0;
+            }
         }
         else
         {
+            floorStuckWindows_ = 0;
             if (minimumProfileHoldWindows_ > 0)
             {
                 minimumProfileHoldWindows_--;
@@ -197,14 +232,25 @@ private:
     static constexpr size_t kWindowSize = 5;
     static constexpr uint32_t kMinBitrateMbps = 10;
     static constexpr uint32_t kStableWindowsBeforeIncrease = 5;
+    static constexpr uint32_t kFloorProbeWindows = 10;
     static constexpr uint32_t kMinimumProfileHoldWindows = 4;
     static constexpr float kConstrainedLatencyMs = 45.0f;
     static constexpr float kConstrainedFrameAgeMs = 55.0f;
     static constexpr float kRecoveryFrameAgeMs = 85.0f;
-    static constexpr float kConstrainedReprojectedFrames = 4.0f;
-    static constexpr float kConstrainedStaleReuses = 6.0f;
-    static constexpr uint32_t kRecoveryReprojectedFrames = 12;
-    static constexpr uint32_t kRecoveryStaleReuses = 18;
+    // Measured on-device: this client's "pose" reprojection mode produces a
+    // steady reproj/stale baseline of ~12-14 per window *independent of
+    // server-side GPU/encode load* (confirmed by varying Mac GPU time 3ms-30ms
+    // with zero change in reproj/stale counts) -- the lateness is real but its
+    // source is delivery/transport timing (likely the USB-ADB-reverse TCP
+    // tunnel), not something bitrate cuts can fix. The old thresholds (4/6)
+    // were below this baseline, so the controller permanently misread normal
+    // operation as "Constrained" and parked bitrate at the floor. Raised past
+    // the observed baseline with headroom so genuine excursions above it still
+    // trigger correction.
+    static constexpr float kConstrainedReprojectedFrames = 20.0f;
+    static constexpr float kConstrainedStaleReuses = 24.0f;
+    static constexpr uint32_t kRecoveryReprojectedFrames = 35;
+    static constexpr uint32_t kRecoveryStaleReuses = 45;
     static constexpr uint32_t kConstrainedFallbacks = 2;
 
     template <typename Getter>
@@ -277,7 +323,9 @@ private:
     float minimumResolutionScale_ = 0.5f;
     uint32_t stableWindows_ = 0;
     uint32_t minimumProfileHoldWindows_ = 0;
+    uint32_t floorStuckWindows_ = 0;
     std::string profile_ = "balanced";
+    float refreshScale_ = 1.0f;
     std::deque<Sample> samples_;
 };
 

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -1722,7 +1722,8 @@ void StreamingServer::HandleClientConnect(const oxr::protocol::ClientConnect& cl
                                  bitrateMbps,
                                  bitrateMbps,
                                  config.resolutionScale,
-                                 config.dynamicResolutionMinScale);
+                                 config.dynamicResolutionMinScale,
+                                 negotiatedRefresh);
             {
                 std::lock_guard<std::mutex> abrLock(abrStateMutex_);
                 abrModeName_ = oxrsys::streaming_abr::ToString(
@@ -1880,7 +1881,8 @@ void StreamingServer::HandleUsbClientConnect(const oxr::protocol::ClientConnect&
                                  bitrateMbps,
                                  bitrateMbps,
                                  config.resolutionScale,
-                                 config.dynamicResolutionMinScale);
+                                 config.dynamicResolutionMinScale,
+                                 negotiatedRefresh);
             {
                 std::lock_guard<std::mutex> abrLock(abrStateMutex_);
                 abrModeName_ = oxrsys::streaming_abr::ToString(

--- a/tests/TestStreamingAbr.cpp
+++ b/tests/TestStreamingAbr.cpp
@@ -75,6 +75,73 @@ TEST_CASE("Streaming ABR off mode does not change bitrate", "[streaming][abr]")
     CHECK(decision.targetBitrateMbps == 80);
 }
 
+TEST_CASE("Streaming ABR escapes the floor when stuck constrained for a non-bitrate reason", "[streaming][abr]")
+{
+    // Reproduces a real stuck state: GPU/timing jitter (not bandwidth) keeps
+    // reprojectedFramesDelta above the constrained threshold no matter how low
+    // bitrate goes, so the controller cuts to the floor and -- without an
+    // escape valve -- stays there forever, since Stable is unreachable while
+    // the non-bitrate-caused symptom persists.
+    Controller controller;
+    controller.Reset(Mode::Bitrate, 100, 100);
+
+    Sample jittery = {};
+    jittery.totalClientLatencyMs = 20.0f;
+    jittery.displayedFrameAgeMs = 20.0f;
+    jittery.reprojectedFramesDelta = 25; // above kConstrainedReprojectedFrames regardless of bitrate
+
+    Decision decision = {};
+    bool reachedFloor = false;
+    bool probedAboveFloorAfterReachingIt = false;
+    for (int i = 0; i < 30; ++i)
+    {
+        decision = controller.Update(jittery);
+        CHECK(decision.state == State::Constrained);
+        if (decision.targetBitrateMbps == 10)
+        {
+            reachedFloor = true;
+        }
+        else if (reachedFloor && decision.targetBitrateMbps > 10)
+        {
+            probedAboveFloorAfterReachingIt = true;
+        }
+    }
+
+    CHECK(reachedFloor); // confirms it did reach the floor first, as before the fix
+    CHECK(probedAboveFloorAfterReachingIt); // ...but didn't stay stuck there permanently
+}
+
+TEST_CASE("Streaming ABR scales reprojection thresholds by refresh rate", "[streaming][abr]")
+{
+    // reprojectedFramesDelta/staleFrameReuses are counted over a fixed
+    // wall-clock report interval, so a higher refresh rate naturally produces
+    // a higher raw count for the same *proportional* smoothness. A count that
+    // would rightly flag 72Hz as constrained should not flag 90Hz as
+    // constrained, since 90/72 = 1.25x more frames render in the same window.
+    Controller controller72;
+    controller72.Reset(Mode::Bitrate, 80, 100, 72);
+
+    Sample sample72 = {};
+    sample72.totalClientLatencyMs = 20.0f;
+    sample72.displayedFrameAgeMs = 20.0f;
+    sample72.reprojectedFramesDelta = 21; // just above the 72Hz-calibrated threshold (20)
+
+    Decision decision72 = controller72.Update(sample72);
+    CHECK(decision72.state == State::Constrained);
+
+    Controller controller90;
+    controller90.Reset(Mode::Bitrate, 80, 100, 90);
+
+    Sample sample90 = {};
+    sample90.totalClientLatencyMs = 20.0f;
+    sample90.displayedFrameAgeMs = 20.0f;
+    sample90.reprojectedFramesDelta = 21; // same raw count, but proportionally equivalent to ~17 at 72Hz
+
+    Decision decision90 = controller90.Update(sample90);
+    CHECK(decision90.state == State::Stable);
+    CHECK(!decision90.bitrateChanged);
+}
+
 TEST_CASE("Streaming ABR full mode selects smooth profiles from reprojection pressure", "[streaming][abr]")
 {
     Controller controller;

--- a/tests/TestStreamingAbr.cpp
+++ b/tests/TestStreamingAbr.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Streaming ABR scales reprojection thresholds by refresh rate", "[stre
     // would rightly flag 72Hz as constrained should not flag 90Hz as
     // constrained, since 90/72 = 1.25x more frames render in the same window.
     Controller controller72;
-    controller72.Reset(Mode::Bitrate, 80, 100, 72);
+    controller72.Reset(Mode::Bitrate, 80, 100, 1.0f, 0.5f, 72);
 
     Sample sample72 = {};
     sample72.totalClientLatencyMs = 20.0f;
@@ -130,7 +130,7 @@ TEST_CASE("Streaming ABR scales reprojection thresholds by refresh rate", "[stre
     CHECK(decision72.state == State::Constrained);
 
     Controller controller90;
-    controller90.Reset(Mode::Bitrate, 80, 100, 90);
+    controller90.Reset(Mode::Bitrate, 80, 100, 1.0f, 0.5f, 90);
 
     Sample sample90 = {};
     sample90.totalClientLatencyMs = 20.0f;


### PR DESCRIPTION
## Summary
- Scale reprojection and stale-frame ABR thresholds by negotiated refresh rate so 90/120 Hz sessions are not treated as permanently constrained.
- Raise constrained/recovery thresholds above the normal USB pose reprojection baseline.
- Probe above the bitrate floor when constraints persist for reasons bitrate cuts cannot fix.

## Test plan
- [x] oxrsys_runtime_tests streaming ABR cases (6 cases, all pass)
- [ ] Quest USB streaming with ABR bitrate/full at 90 Hz; verify bitrate is not pinned at the floor during healthy playback

Made with [Cursor](https://cursor.com)