### PR TITLE
Preserve signed float action values when aggregating bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Fixed server-side foveated encoding on Metal by running the AADT pass through a compute shader into a private GPU scratch texture before blitting into the VideoToolbox pixel buffer, avoiding render-encoder validation aborts on the first encoded frame.
 - Fixed Quest connection recovery when a server is discovered but no first video frame arrives, returning the client to discovery/retry instead of leaving the standby/loading screen stuck.
 - Fixed controller pose handling so streaming packets only update controller poses when the corresponding controller-active flag is present.
+- Fixed float action aggregation so bidirectional axes such as thumbsticks preserve negative deflection instead of being clamped by `std::max()`.
 - Fixed hand tracking and hand-interaction coexistence so hand bindings remain available while controller bindings keep priority for shared actions.
 - Fixed Quest hand tracking ingestion by feeding real `XR_EXT_hand_tracking` joints from the Android client into the runtime.
 - Fixed USB ADB reverse TCP reconnect behavior so closed control/video sockets or video stalls return the Android client to discovery/retry without relaunching the client.

--- a/runtime/src/EntryPoint.cpp
+++ b/runtime/src/EntryPoint.cpp
@@ -2058,7 +2058,12 @@ static ActionState::SubactionData GetQueriedActionState(const ActionState* actio
         aggregate.isActive = aggregate.isActive || data.isActive;
         aggregate.boolValue = aggregate.boolValue || data.boolValue;
         aggregate.boolChanged = aggregate.boolChanged || data.boolChanged;
-        aggregate.floatValue = std::max(aggregate.floatValue, data.floatValue);
+        // Magnitude-preserving so bidirectional axes (thumbstick x/y) keep their sign;
+        // identical to max() for one-sided inputs (trigger/grip are always >= 0).
+        if (std::fabs(data.floatValue) > std::fabs(aggregate.floatValue))
+        {
+            aggregate.floatValue = data.floatValue;
+        }
         aggregate.floatChanged = aggregate.floatChanged || data.floatChanged;
         if (std::fabs(data.vector2fValue.x) > std::fabs(aggregate.vector2fValue.x) ||
             std::fabs(data.vector2fValue.y) > std::fabs(aggregate.vector2fValue.y))
@@ -2194,10 +2199,17 @@ static void AccumulateBindingState(const InputManager& inputManager, const Sugge
             break;
 
         case XR_ACTION_TYPE_FLOAT_INPUT:
-            aggregate.floatValue = std::max(aggregate.floatValue,
-                                            inputManager.GetFloatComponentForProfile(
-                                                hand, binding.componentPath, binding.profilePathString));
+        {
+            // Magnitude-preserving so bidirectional axes keep their sign (max() would clamp
+            // negative thumbstick deflection to 0). One-sided inputs are unaffected.
+            const float floatComponent = inputManager.GetFloatComponentForProfile(
+                hand, binding.componentPath, binding.profilePathString);
+            if (std::fabs(floatComponent) > std::fabs(aggregate.floatValue))
+            {
+                aggregate.floatValue = floatComponent;
+            }
             break;
+        }
 
         case XR_ACTION_TYPE_VECTOR2F_INPUT:
         {


### PR DESCRIPTION
## Summary
- Replace std::max float aggregation with magnitude-preserving selection so bidirectional axes such as thumbsticks keep negative deflection.
- One-sided inputs such as triggers remain unchanged.

## Test plan
- [x] macOS runtime tests build
- [ ] Verify thumbstick left/down deflection reaches streamed apps while multiple bindings are active

Made with [Cursor](https://cursor.com)