### PR TITLE
Fix Quest refresh rate reporting after display refresh request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 - Hardened Quest headset foveation shutdown by detaching the foveation profile from swapchains before destroying it.
 - Hardened runtime-managed Quest logcat capture so it remains optional, bounded, and best-effort during startup.
 - Fixed render-pose matching on headset clients so decoded frames are submitted with the pose used to render that frame.
+- Fixed Quest refresh-rate reporting by trusting the successful `xrRequestDisplayRefreshRateFB` value instead of immediately querying the asynchronous runtime readback.
 - Filtered known macOS `linkd.autoShortcut` App Intents diagnostics from Home captured app logs.
 - Fixed and covered `xrLocateSpacesKHR` as an alias for the OpenXR 1.1 `xrLocateSpaces` entry point.
 

--- a/clients/Android/android-vr/app/src/main/cpp/XrApp.cpp
+++ b/clients/Android/android-vr/app/src/main/cpp/XrApp.cpp
@@ -1494,25 +1494,14 @@ bool XrApp::InitializeDisplayRefreshRate(float preferredRefreshRateHz)
 
     LOGI("Requested display refresh rate: %.1fHz", preferredRefreshRateHz);
 
-    if (xrGetDisplayRefreshRateFB_ != nullptr)
-    {
-        float currentRate = 0.0f;
-        if (XR_SUCCEEDED(xrGetDisplayRefreshRateFB_(session_, &currentRate)))
-        {
-            LOGI("Current display refresh rate after request: %.1fHz", currentRate);
-            clientRefreshRateHz_ = static_cast<uint32_t>(std::max(1.0f, std::round(currentRate)));
-        }
-        else
-        {
-            clientRefreshRateHz_ =
-                static_cast<uint32_t>(std::max(1.0f, std::round(preferredRefreshRateHz)));
-        }
-    }
-    else
-    {
-        clientRefreshRateHz_ =
-            static_cast<uint32_t>(std::max(1.0f, std::round(preferredRefreshRateHz)));
-    }
+    // xrRequestDisplayRefreshRateFB is asynchronous -- the runtime hasn't
+    // necessarily applied the new rate by the time this function returns, so
+    // querying xrGetDisplayRefreshRateFB right here is racy and can read back
+    // the *old* rate, silently reporting the wrong refresh to the server for
+    // the lifetime of the connection. We already confirmed preferredRefreshRateHz
+    // is in the supported list (hasPreferredRate above) and the request itself
+    // succeeded, so just trust it instead of an immediate, unreliable read-back.
+    clientRefreshRateHz_ = static_cast<uint32_t>(std::max(1.0f, std::round(preferredRefreshRateHz)));
 
     return true;
 }


### PR DESCRIPTION
## Summary
- Stop querying xrGetDisplayRefreshRateFB immediately after xrRequestDisplayRefreshRateFB.
- Trust the supported requested rate after a successful request so the client does not report the previous refresh rate to the server for the whole session.

## Test plan
- [ ] Request 90/120 Hz from Home and confirm the runtime negotiates the requested rate instead of the pre-request readback

Made with [Cursor](https://cursor.com)