### PR TITLE
Implement XR_KHR_convert_timespec_time

### DIFF
--- a/runtime/src/EntryPoint.cpp
+++ b/runtime/src/EntryPoint.cpp
@@ -340,6 +340,9 @@ static std::vector<ExtensionInfo> GetSupportedExtensionInfos()
         {XR_KHR_METAL_ENABLE_EXTENSION_NAME, XR_KHR_metal_enable_SPEC_VERSION},
         {UNITY_METAL_ENABLE_EXTENSION_ALIAS, XR_KHR_metal_enable_SPEC_VERSION},
 #endif
+#ifdef XR_USE_TIMESPEC
+        {XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME, XR_KHR_convert_timespec_time_SPEC_VERSION},
+#endif
         {XR_EXT_HAND_TRACKING_EXTENSION_NAME, XR_EXT_hand_tracking_SPEC_VERSION},
         {XR_EXT_CONFORMANCE_AUTOMATION_EXTENSION_NAME, XR_EXT_conformance_automation_SPEC_VERSION},
         {XR_EXT_HAND_INTERACTION_EXTENSION_NAME, XR_EXT_hand_interaction_SPEC_VERSION},
@@ -421,6 +424,13 @@ static const char* ExtensionForFunctionName(const char* functionName)
     {
         return XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
     }
+#ifdef XR_USE_TIMESPEC
+    if (std::strcmp(functionName, "xrConvertTimespecTimeToTimeKHR") == 0 ||
+        std::strcmp(functionName, "xrConvertTimeToTimespecTimeKHR") == 0)
+    {
+        return XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME;
+    }
+#endif
 #ifdef XR_USE_GRAPHICS_API_METAL
     if (std::strcmp(functionName, "xrGetMetalGraphicsRequirementsKHR") == 0 ||
         std::strcmp(functionName, UNITY_METAL_GRAPHICS_REQUIREMENTS_FUNCTION_ALIAS) == 0)
@@ -4008,6 +4018,78 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrGetMetalGraphicsRequirementsKHR(
 // xrGetInstanceProcAddr — the main dispatch function
 // ============================================================================
 
+#ifdef XR_USE_TIMESPEC
+// ============================================================================
+// XR_KHR_convert_timespec_time — CLOCK_MONOTONIC timespec <-> XrTime. The
+// session owns the exact time base (monoStartNs_); before a session exists we
+// fall back to a process-global monotonic epoch so conversions never hard-fail.
+// ============================================================================
+static int64_t MonotonicFallbackEpochNs()
+{
+    // Function-local static: C++11 guarantees the initializer runs exactly once
+    // even under concurrent conversion calls before any session exists.
+    static const int64_t epochNs = []() -> int64_t {
+        struct timespec ts{};
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return static_cast<int64_t>(ts.tv_sec) * 1000000000LL + ts.tv_nsec;
+    }();
+    return epochNs;
+}
+
+static XRAPI_ATTR XrResult XRAPI_CALL OxrConvertTimespecTimeToTimeKHR(
+    XrInstance instance, const struct timespec* timespecTime, XrTime* time)
+{
+    Instance* inst = GetInstance(instance);
+    if (inst == nullptr)
+    {
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (timespecTime == nullptr || time == nullptr ||
+        timespecTime->tv_nsec < 0 || timespecTime->tv_nsec >= 1000000000L)
+    {
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    if (Session* sess = inst->GetSession())
+    {
+        *time = sess->TimespecToXrTime(*timespecTime);
+    }
+    else
+    {
+        const int64_t monoNs =
+            static_cast<int64_t>(timespecTime->tv_sec) * 1000000000LL + timespecTime->tv_nsec;
+        *time = static_cast<XrTime>(monoNs - MonotonicFallbackEpochNs());
+    }
+    return XR_SUCCESS;
+}
+
+static XRAPI_ATTR XrResult XRAPI_CALL OxrConvertTimeToTimespecTimeKHR(
+    XrInstance instance, XrTime time, struct timespec* timespecTime)
+{
+    Instance* inst = GetInstance(instance);
+    if (inst == nullptr)
+    {
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (timespecTime == nullptr)
+    {
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    if (Session* sess = inst->GetSession())
+    {
+        sess->XrTimeToTimespec(time, *timespecTime);
+    }
+    else
+    {
+        const int64_t monoNs = static_cast<int64_t>(time) + MonotonicFallbackEpochNs();
+        timespecTime->tv_sec = static_cast<time_t>(monoNs / 1000000000LL);
+        timespecTime->tv_nsec = static_cast<long>(monoNs % 1000000000LL);
+    }
+    return XR_SUCCESS;
+}
+#endif
+
 static XRAPI_ATTR XrResult XRAPI_CALL OxrGetInstanceProcAddr(
     XrInstance instance, const char* name, PFN_xrVoidFunction* function);
 
@@ -4135,6 +4217,12 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrGetInstanceProcAddr(
     DISPATCH(xrSessionBeginDebugUtilsLabelRegionEXT, OxrSessionBeginDebugUtilsLabelRegionEXT)
     DISPATCH(xrSessionEndDebugUtilsLabelRegionEXT, OxrSessionEndDebugUtilsLabelRegionEXT)
     DISPATCH(xrSessionInsertDebugUtilsLabelEXT, OxrSessionInsertDebugUtilsLabelEXT)
+
+    // Convert timespec time extension
+#ifdef XR_USE_TIMESPEC
+    DISPATCH(xrConvertTimespecTimeToTimeKHR, OxrConvertTimespecTimeToTimeKHR)
+    DISPATCH(xrConvertTimeToTimespecTimeKHR, OxrConvertTimeToTimespecTimeKHR)
+#endif
 
     // Metal extension
 #ifdef XR_USE_GRAPHICS_API_METAL

--- a/runtime/src/OpenXRPlatform.h
+++ b/runtime/src/OpenXRPlatform.h
@@ -35,6 +35,15 @@
 #endif
 #endif
 
+#if !defined(_WIN32)
+// Enable the XR_KHR_convert_timespec_time declarations
+// (xrConvertTimespecTimeToTimeKHR et al.) in openxr_platform.h.
+#include <ctime>
+#ifndef XR_USE_TIMESPEC
+#define XR_USE_TIMESPEC
+#endif
+#endif
+
 #include <openxr/openxr_platform.h>
 
 #if defined(XR_USE_PLATFORM_XLIB) && defined(None)

--- a/runtime/src/Session.cpp
+++ b/runtime/src/Session.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstring>
+#include <ctime>
 #include <numeric>
 #include <thread>
 #include <utility>
@@ -22,6 +23,17 @@ namespace
 {
 
 using Clock = std::chrono::steady_clock;
+
+#if !defined(_WIN32)
+// CLOCK_MONOTONIC in nanoseconds — the clock XR_KHR_convert_timespec_time
+// converts against.
+int64_t MonotonicNowNs()
+{
+    struct timespec ts{};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<int64_t>(ts.tv_sec) * 1000000000LL + ts.tv_nsec;
+}
+#endif
 
 struct SessionMetricSummary
 {
@@ -103,6 +115,9 @@ Session::Session(Instance* instance, void* metalDevice, void* metalCommandQueue)
     inputManager_ = std::make_unique<InputManager>();
 
     startTime_ = std::chrono::steady_clock::now();
+#if !defined(_WIN32)
+    monoStartNs_ = MonotonicNowNs();
+#endif
     lastFrameTime_ = startTime_;
 
     Runtime::Get().RegisterHandle(handle_, this);
@@ -120,6 +135,9 @@ Session::Session(Instance* instance, const GraphicsContext& graphicsContext)
     inputManager_ = std::make_unique<InputManager>();
 
     startTime_ = std::chrono::steady_clock::now();
+#if !defined(_WIN32)
+    monoStartNs_ = MonotonicNowNs();
+#endif
     lastFrameTime_ = startTime_;
 
     Runtime::Get().RegisterHandle(handle_, this);
@@ -166,6 +184,23 @@ XrTime Session::GetCurrentTime() const
             std::chrono::steady_clock::now() - startTime_)
             .count());
 }
+
+#if !defined(_WIN32)
+XrTime Session::TimespecToXrTime(const struct timespec& ts) const
+{
+    const int64_t monoNs = static_cast<int64_t>(ts.tv_sec) * 1000000000LL + ts.tv_nsec;
+    // XrTime == steady_clock::now() - startTime_, and CLOCK_MONOTONIC advances in
+    // lockstep with steady_clock (both real-time ns), so XrTime == monoNs - monoStartNs_.
+    return static_cast<XrTime>(monoNs - monoStartNs_);
+}
+
+void Session::XrTimeToTimespec(XrTime time, struct timespec& ts) const
+{
+    const int64_t monoNs = static_cast<int64_t>(time) + monoStartNs_;
+    ts.tv_sec = static_cast<time_t>(monoNs / 1000000000LL);
+    ts.tv_nsec = static_cast<long>(monoNs % 1000000000LL);
+}
+#endif
 
 void Session::TransitionState(XrSessionState newState)
 {

--- a/runtime/src/Session.h
+++ b/runtime/src/Session.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <chrono>
 #include <cstdint>
+#include <ctime>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -92,6 +93,13 @@ public:
     }
 
     XrTime GetCurrentTime() const;
+#if !defined(_WIN32)
+    // XR_KHR_convert_timespec_time helpers. CLOCK_MONOTONIC is captured at the
+    // same instant startTime_ is set (monoStartNs_), so XrTime == mono_ns -
+    // monoStartNs_ and the mapping is a pure offset consistent with GetCurrentTime().
+    XrTime TimespecToXrTime(const struct timespec& ts) const;
+    void XrTimeToTimespec(XrTime time, struct timespec& ts) const;
+#endif
     void BeginDebugUtilsLabelRegion(const XrDebugUtilsLabelEXT& labelInfo);
     void EndDebugUtilsLabelRegion();
     void InsertDebugUtilsLabel(const XrDebugUtilsLabelEXT& labelInfo);
@@ -136,6 +144,10 @@ private:
     std::vector<std::unique_ptr<Space>> spaces_;
 
     std::chrono::steady_clock::time_point startTime_;
+#if !defined(_WIN32)
+    // CLOCK_MONOTONIC nanoseconds sampled at the same instant as startTime_.
+    int64_t monoStartNs_ = 0;
+#endif
     std::chrono::steady_clock::time_point lastFrameTime_;
 
     std::vector<DebugUtilsLabelState> debugUtilsLabelRegions_;

--- a/tests/TestRuntimeApi.cpp
+++ b/tests/TestRuntimeApi.cpp
@@ -2583,6 +2583,85 @@ TEST_CASE("EndFrame rejects invalid projection and quad layers", "[runtime][fram
         XR_ERROR_VALIDATION_FAILURE);
 }
 
+TEST_CASE("XR_KHR_convert_timespec_time bridges CLOCK_MONOTONIC and XrTime", "[runtime][timespec]")
+{
+    // Both conversion directions must be resolvable and must round-trip losslessly.
+    // Exercise the no-session fallback epoch (process-global) and the
+    // active-session time base.
+
+    SECTION("No-session fallback rejects bad input and round-trips losslessly")
+    {
+        const char* extensions[] = {XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME};
+        XrInstanceCreateInfo createInfo = {XR_TYPE_INSTANCE_CREATE_INFO};
+        std::strncpy(createInfo.applicationInfo.applicationName, "oxrsys_runtime_api_tests",
+                     XR_MAX_APPLICATION_NAME_SIZE);
+        createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+        createInfo.enabledExtensionCount = 1;
+        createInfo.enabledExtensionNames = extensions;
+        XrInstance instance = XR_NULL_HANDLE;
+        XR_CHECK(xrCreateInstance(&createInfo, &instance));
+
+        auto convertTimespecToTime = reinterpret_cast<PFN_xrConvertTimespecTimeToTimeKHR>(
+            GetProc(instance, "xrConvertTimespecTimeToTimeKHR"));
+        auto convertTimeToTimespec = reinterpret_cast<PFN_xrConvertTimeToTimespecTimeKHR>(
+            GetProc(instance, "xrConvertTimeToTimespecTimeKHR"));
+
+        // Out-of-range tv_nsec is rejected in both parameter forms.
+        struct timespec badTimespec{};
+        badTimespec.tv_sec = 100;
+        badTimespec.tv_nsec = 1'000'000'000L; // == 1e9 is out of [0, 1e9)
+        XrTime scratch = 0;
+        CHECK(convertTimespecToTime(instance, &badTimespec, &scratch) ==
+              XR_ERROR_VALIDATION_FAILURE);
+        badTimespec.tv_nsec = -1;
+        CHECK(convertTimespecToTime(instance, &badTimespec, &scratch) ==
+              XR_ERROR_VALIDATION_FAILURE);
+
+        struct timespec now{};
+        REQUIRE(clock_gettime(CLOCK_MONOTONIC, &now) == 0);
+        XrTime xrTime = 0;
+        XR_CHECK(convertTimespecToTime(instance, &now, &xrTime));
+        struct timespec roundTrip{};
+        XR_CHECK(convertTimeToTimespec(instance, xrTime, &roundTrip));
+        CHECK(roundTrip.tv_sec == now.tv_sec);
+        CHECK(roundTrip.tv_nsec == now.tv_nsec);
+
+        XR_CHECK(xrDestroyInstance(instance));
+    }
+
+    SECTION("Active session shares its time base with predicted display time")
+    {
+        RuntimeSessionContext context({
+            XR_KHR_METAL_ENABLE_EXTENSION_NAME,
+            XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME,
+        });
+
+        auto convertTimespecToTime = reinterpret_cast<PFN_xrConvertTimespecTimeToTimeKHR>(
+            GetProc(context.instance, "xrConvertTimespecTimeToTimeKHR"));
+        auto convertTimeToTimespec = reinterpret_cast<PFN_xrConvertTimeToTimespecTimeKHR>(
+            GetProc(context.instance, "xrConvertTimeToTimespecTimeKHR"));
+
+        // Round-trip against the session's own time base.
+        struct timespec now{};
+        REQUIRE(clock_gettime(CLOCK_MONOTONIC, &now) == 0);
+        XrTime xrNow = 0;
+        XR_CHECK(convertTimespecToTime(context.instance, &now, &xrNow));
+        struct timespec roundTrip{};
+        XR_CHECK(convertTimeToTimespec(context.instance, xrNow, &roundTrip));
+        CHECK(roundTrip.tv_sec == now.tv_sec);
+        CHECK(roundTrip.tv_nsec == now.tv_nsec);
+
+        // Domain sanity: the XrTime for "now" must sit in the same base as the frame
+        // loop's predicted display time (within a generous few-second bound).
+        XrFrameState frameState = {XR_TYPE_FRAME_STATE};
+        XR_CHECK(xrWaitFrame(context.session, nullptr, &frameState));
+        const int64_t deltaNs =
+            std::llabs(static_cast<int64_t>(frameState.predictedDisplayTime) -
+                       static_cast<int64_t>(xrNow));
+        CHECK(deltaNs < 5'000'000'000LL);
+    }
+}
+
 TEST_CASE("EndFrame accepts a released projection image while another swapchain image is acquired", "[runtime][frame][swapchain]")
 {
     RuntimeSessionContext context({XR_KHR_METAL_ENABLE_EXTENSION_NAME});


### PR DESCRIPTION
This adds `XR_KHR_convert_timespec_time` on non-Windows platforms: `xrConvertTimespecTimeToTimeKHR` / `xrConvertTimeToTimespecTimeKHR` map CLOCK_MONOTONIC timespec values to and from `XrTime` as a pure offset against the session's time base (CLOCK_MONOTONIC is sampled at the same instant as `startTime_`, so conversions stay consistent with `GetCurrentTime()` and predicted display times). Before a session exists, conversions fall back to a race-free process-global monotonic epoch rather than failing. This is the standard portable time-conversion extension for POSIX platforms — Monado implements it the same way — and it lets applications and tools correlate external CLOCK_MONOTONIC timestamps with runtime frame timing.

Everything is compiled out on Windows (`XR_USE_TIMESPEC` is only defined when `!_WIN32`), so the Windows build is unaffected. A new runtime API test covers both directions: `tv_nsec` range validation, a lossless round-trip through the no-session fallback epoch, a lossless round-trip against a live session's time base, and a domain-sanity check that a converted "now" lands within a few seconds of `xrWaitFrame`'s `predictedDisplayTime`.