### PR TITLE
Fix the Windows build and client discovery/liveness: loopback beacon, dead-client watchdog, streaming-thread QoS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(OXRSYS_LOGCAT_TEST_ENV
 )
 
 add_executable(oxrsys_runtime_tests
+    tests/TestClientLiveness.cpp
     tests/TestConfig.cpp
     tests/TestInputManager.cpp
     tests/TestRuntimePlatform.cpp

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -292,9 +292,12 @@ configure_file(
     @ONLY
 )
 
-# Copy manifest JSON next to the dylib
+# Copy manifest JSON next to the dylib. TARGET_FILE_DIR rather than
+# CMAKE_CURRENT_BINARY_DIR so multi-config generators (Visual Studio) put it
+# beside the per-config binary, which is where the test environment points
+# XR_RUNTIME_JSON. Single-config generators resolve to the same directory.
 file(GENERATE
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oxrsys-runtime.json
+    OUTPUT $<TARGET_FILE_DIR:oxrsys_runtime>/oxrsys-runtime.json
     INPUT ${CMAKE_CURRENT_BINARY_DIR}/oxrsys-runtime.json.in.configured
 )
 

--- a/runtime/oxrsys-runtime.json.in
+++ b/runtime/oxrsys-runtime.json.in
@@ -2,6 +2,6 @@
     "file_format_version": "1.0.0",
     "runtime": {
         "name": "OXRSys Runtime",
-        "library_path": "@CMAKE_CURRENT_BINARY_DIR@/@OXRSYS_RUNTIME_LIBRARY_FILENAME@"
+        "library_path": "./@OXRSYS_RUNTIME_LIBRARY_FILENAME@"
     }
 }

--- a/runtime/src/ClientLiveness.h
+++ b/runtime/src/ClientLiveness.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Pure client-liveness decision, factored out of StreamingServer so the reconnect
+// watchdog (abrupt UDP client kill -> resume broadcast) is unit-testable without
+// a live session. StreamingServer holds the state in atomics and only evaluates
+// it from SendFrame, i.e. while the app is still submitting frames.
+namespace oxrsys
+{
+
+// Snapshot of what the watchdog remembers between checks: the tracking packet
+// count last observed, and the clock reading when activity was last seen.
+struct ClientLivenessState
+{
+    uint64_t lastCountSeen = 0;
+    int64_t lastActivityNs = 0;
+};
+
+struct ClientLivenessDecision
+{
+    ClientLivenessState state; // stored back by the caller
+    bool disconnect = false;   // client is considered gone
+};
+
+// Decides whether a connected client is still alive. A change in the tracking
+// packet count since prev.lastCountSeen resets the activity clock to nowNs. Once
+// the count has stalled, the client is declared disconnected when the last
+// activity is older than timeoutNs — but only if activity was ever recorded
+// (lastActivityNs != 0), so a client that has produced no packets yet is never
+// disconnected on this path.
+inline ClientLivenessDecision EvaluateClientLiveness(const ClientLivenessState& prev,
+                                                     uint64_t currentCount, int64_t nowNs,
+                                                     int64_t timeoutNs)
+{
+    ClientLivenessDecision decision;
+    decision.state = prev;
+    if (currentCount != prev.lastCountSeen)
+    {
+        decision.state.lastCountSeen = currentCount;
+        decision.state.lastActivityNs = nowNs;
+        return decision;
+    }
+    if (prev.lastActivityNs != 0 && nowNs - prev.lastActivityNs > timeoutNs)
+    {
+        decision.disconnect = true;
+    }
+    return decision;
+}
+
+} // namespace oxrsys

--- a/runtime/src/RuntimePlatform.cpp
+++ b/runtime/src/RuntimePlatform.cpp
@@ -15,6 +15,13 @@
 #include <unistd.h>
 #endif
 
+#if defined(__APPLE__)
+#include <pthread/qos.h>
+#elif defined(__linux__)
+#include <pthread.h>
+#include <sched.h>
+#endif
+
 namespace oxrsys::runtime_platform
 {
 
@@ -151,6 +158,21 @@ uint64_t ProcessId()
     return static_cast<uint64_t>(GetCurrentProcessId());
 #else
     return static_cast<uint64_t>(getpid());
+#endif
+}
+
+void SetCurrentThreadTimeSensitive()
+{
+#if defined(__APPLE__)
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+#elif defined(_WIN32)
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
+#elif defined(__linux__)
+    // Realtime policies need CAP_SYS_NICE; unprivileged processes silently
+    // keep SCHED_OTHER.
+    sched_param param = {};
+    param.sched_priority = sched_get_priority_min(SCHED_FIFO);
+    pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
 #endif
 }
 

--- a/runtime/src/RuntimePlatform.h
+++ b/runtime/src/RuntimePlatform.h
@@ -33,4 +33,9 @@ std::string StateRoot();
 std::string ModuleDirectory(const void* symbolAddress);
 uint64_t ProcessId();
 
+// Raise the calling thread's scheduling priority so time-sensitive per-frame
+// work is not delayed behind default-priority threads. Best effort on every
+// platform: failures just keep the default policy.
+void SetCurrentThreadTimeSensitive();
+
 } // namespace oxrsys::runtime_platform

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <limits>
+#include <bit>
 #include <numeric>
 #include <system_error>
 #include <thread>
@@ -3091,7 +3092,7 @@ void StreamingServer::HandleNackRequest(const oxr::protocol::NackRequest& reques
     std::string clientIp;
     SocketHandle videoSocket = oxrsys::runtime_socket::InvalidSocket;
     std::vector<RetransmitPacket> retransmitPackets;
-    retransmitPackets.reserve(static_cast<size_t>(__builtin_popcountll(request.missingBitmask)));
+    retransmitPackets.reserve(static_cast<size_t>(std::popcount(request.missingBitmask)));
 
     {
         std::lock_guard<std::mutex> lock(packetDispatchState_->mutex);
@@ -3171,7 +3172,7 @@ void StreamingServer::HandleNackRequest(const oxr::protocol::NackRequest& reques
     {
         videoUdpRetransmittedPackets_.fetch_add(retransmitted);
         spdlog::info("StreamingServer: NACK retransmitted {}/{} packets for frame {}",
-                      retransmitted, __builtin_popcountll(request.missingBitmask),
+                      retransmitted, std::popcount(request.missingBitmask),
                       request.frameIndex);
     }
 }

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -3,6 +3,7 @@
 #include "StreamingServer.h"
 #include "ClientLiveness.h"
 #include "Config.h"
+#include "RuntimePlatform.h"
 #include "RuntimeSockets.h"
 #include "RuntimeStatus.h"
 #include "StreamingTransportPolicy.h"
@@ -1371,6 +1372,7 @@ void StreamingServer::TcpSpatialThread()
 
 void StreamingServer::EncodeThread()
 {
+    oxrsys::runtime_platform::SetCurrentThreadTimeSensitive();
     auto telemetry = std::make_shared<EncodeTelemetry>();
     std::shared_ptr<PacketDispatchState> packetDispatchState = packetDispatchState_;
 
@@ -2702,6 +2704,7 @@ void StreamingServer::ClearVideoSendQueue()
 
 void StreamingServer::VideoSendThread()
 {
+    oxrsys::runtime_platform::SetCurrentThreadTimeSensitive();
     while (running_.load())
     {
         TickPendingStreamConfigTimeout(SteadyClockNowNs());

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "StreamingServer.h"
+#include "ClientLiveness.h"
 #include "Config.h"
 #include "RuntimeSockets.h"
 #include "RuntimeStatus.h"
@@ -48,6 +49,10 @@ constexpr int64_t kStreamConfigAckTimeoutNs =
     std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::milliseconds(500)).count();
 constexpr uint32_t kStreamConfigMaxRetries = 2;
+// Treat a connected client as gone if it sends no tracking for this long (abrupt UDP kill).
+constexpr int64_t kClientLivenessTimeoutNs =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::seconds(3)).count();
 
 int64_t SteadyClockNowNs()
 {
@@ -1727,6 +1732,9 @@ void StreamingServer::HandleClientConnect(const oxr::protocol::ClientConnect& cl
     UpdatePredictionHorizon();
 
     state_.store(State::Connected);
+    lastClientActivityNs_.store(SteadyClockNowNs(), std::memory_order_relaxed);
+    lastTrackingCountSeen_.store(
+        trackingReceiver_ ? trackingReceiver_->GetPacketCount() : 0, std::memory_order_relaxed);
 
     {
         std::lock_guard<std::mutex> broadcastLock(broadcastThreadMutex_);
@@ -1890,6 +1898,9 @@ void StreamingServer::HandleUsbClientConnect(const oxr::protocol::ClientConnect&
     UpdatePredictionHorizon();
 
     state_.store(State::Connected);
+    lastClientActivityNs_.store(SteadyClockNowNs(), std::memory_order_relaxed);
+    lastTrackingCountSeen_.store(
+        trackingReceiver_ ? trackingReceiver_->GetPacketCount() : 0, std::memory_order_relaxed);
 
     {
         std::lock_guard<std::mutex> broadcastLock(broadcastThreadMutex_);
@@ -2555,10 +2566,36 @@ void StreamingServer::UpdatePredictionHorizon()
     trackingReceiver_->SetPredictionHorizonMs(horizonMs);
 }
 
+void StreamingServer::CheckClientLiveness(int64_t nowNs)
+{
+    // Only reached from SendFrame, so liveness is evaluated while the app is
+    // still submitting frames.
+    if (state_.load() != State::Connected)
+    {
+        return;
+    }
+    const uint64_t count = trackingReceiver_ ? trackingReceiver_->GetPacketCount() : 0;
+    const oxrsys::ClientLivenessState prev{
+        lastTrackingCountSeen_.load(std::memory_order_relaxed),
+        lastClientActivityNs_.load(std::memory_order_relaxed)};
+    const oxrsys::ClientLivenessDecision decision =
+        oxrsys::EvaluateClientLiveness(prev, count, nowNs, kClientLivenessTimeoutNs);
+    lastTrackingCountSeen_.store(decision.state.lastCountSeen, std::memory_order_relaxed);
+    lastClientActivityNs_.store(decision.state.lastActivityNs, std::memory_order_relaxed);
+    if (decision.disconnect)
+    {
+        spdlog::warn("StreamingServer: no client tracking for {} ms; treating client as "
+                     "disconnected and resuming broadcast",
+                     (nowNs - prev.lastActivityNs) / 1'000'000);
+        HandleClientDisconnect();
+    }
+}
+
 void StreamingServer::SendFrame(FrameSource frameSource,
                                 const float* renderHeadOrientation,
                                 const float* renderHeadPosition)
 {
+    CheckClientLiveness(SteadyClockNowNs());
     if (!frameSource.IsStereoValid() || state_.load() != State::Connected)
     {
         return;

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -841,6 +841,13 @@ void StreamingServer::Stop()
     running_.store(false);
     state_.store(State::Stopped);
     frameQueue_.Stop();
+    {
+        // Taking the queue lock orders the running_ store against
+        // VideoSendThread's predicate check; a notify issued between the
+        // check and the wait would otherwise be lost and the join below
+        // would block forever.
+        std::lock_guard<std::mutex> videoSendLock(videoSendMutex_);
+    }
     videoSendCv_.notify_all();
     RuntimeStatus::SetIdle();
     SendUsbDisconnectBestEffort();

--- a/runtime/src/StreamingServer.cpp
+++ b/runtime/src/StreamingServer.cpp
@@ -891,19 +891,32 @@ void StreamingServer::BroadcastThread()
 {
     oxr::protocol::ServerAnnounce announce = BuildServerAnnounce(false);
 
-    sockaddr_in broadcastAddr = {};
-    broadcastAddr.sin_family = AF_INET;
-    broadcastAddr.sin_port = htons(oxr::protocol::DISCOVERY_PORT);
-    broadcastAddr.sin_addr.s_addr = INADDR_BROADCAST;
+    // Beacon to the subnet broadcast and to loopback: macOS does not loop a
+    // 255.255.255.255 broadcast back to local listeners, so a same-machine
+    // client (e.g. the simulator) needs the explicit loopback copy.
+    auto makeTarget = [](uint32_t addr) {
+        sockaddr_in sa = {};
+        sa.sin_family = AF_INET;
+        sa.sin_port = htons(oxr::protocol::DISCOVERY_PORT);
+        sa.sin_addr.s_addr = addr;
+        return sa;
+    };
+    const sockaddr_in targets[] = {
+        makeTarget(INADDR_BROADCAST),
+        makeTarget(htonl(INADDR_LOOPBACK)),
+    };
 
     while (running_.load() && state_.load() == State::Broadcasting)
     {
-        oxrsys::runtime_socket::SendTo(broadcastSocket_,
-                                       &announce,
-                                       sizeof(announce),
-                                       0,
-                                       (sockaddr*)&broadcastAddr,
-                                       sizeof(broadcastAddr));
+        for (const sockaddr_in& target : targets)
+        {
+            oxrsys::runtime_socket::SendTo(broadcastSocket_,
+                                           &announce,
+                                           sizeof(announce),
+                                           0,
+                                           (const sockaddr*)&target,
+                                           sizeof(target));
+        }
 
         for (int i = 0; i < 10 && running_.load() && state_.load() == State::Broadcasting; i++)
         {

--- a/runtime/src/StreamingServer.h
+++ b/runtime/src/StreamingServer.h
@@ -171,6 +171,11 @@ private:
                              const sockaddr_in& clientAddr);
     void HandleUsbClientConnect(const oxr::protocol::ClientConnect& clientConnect);
     void HandleClientDisconnect();
+    // Watchdog: if a connected client stops sending tracking (e.g. killed abruptly on the
+    // WiFi/UDP path, which sends no disconnect), resume broadcasting so a new client can find us.
+    void CheckClientLiveness(int64_t nowNs);
+    std::atomic<uint64_t> lastTrackingCountSeen_{0};
+    std::atomic<int64_t> lastClientActivityNs_{0};
     void HandleLatencyReport(const oxr::protocol::LatencyReport& report);
     void HandleKeyframeRequest(const oxr::protocol::RequestKeyframe& request);
     void HandleStreamConfigAck(const oxr::protocol::StreamConfigAck& ack);

--- a/tests/TestClientLiveness.cpp
+++ b/tests/TestClientLiveness.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ClientLiveness.h"
+
+#include <cstdint>
+
+using oxrsys::ClientLivenessState;
+using oxrsys::EvaluateClientLiveness;
+
+namespace
+{
+constexpr int64_t kTimeoutNs = 3'000'000'000; // 3s, matching kClientLivenessTimeoutNs
+constexpr int64_t kMs = 1'000'000;
+} // namespace
+
+TEST_CASE("Client liveness: a new packet count resets the activity clock", "[client-liveness]")
+{
+    const ClientLivenessState prev{/*lastCountSeen=*/10, /*lastActivityNs=*/1'000 * kMs};
+    // Count advanced and now is far past the timeout, but the advance itself is
+    // proof of life: no disconnect, and the clock moves to now.
+    const auto decision = EvaluateClientLiveness(prev, /*currentCount=*/11,
+                                                 /*nowNs=*/10'000 * kMs, kTimeoutNs);
+    CHECK_FALSE(decision.disconnect);
+    CHECK(decision.state.lastCountSeen == 11);
+    CHECK(decision.state.lastActivityNs == 10'000 * kMs);
+}
+
+TEST_CASE("Client liveness: silence under the timeout keeps the client", "[client-liveness]")
+{
+    const ClientLivenessState prev{/*lastCountSeen=*/10, /*lastActivityNs=*/1'000 * kMs};
+    // Same count 2.5s later: under the 3s threshold, so the client survives and
+    // the remembered state is unchanged.
+    const auto decision = EvaluateClientLiveness(prev, /*currentCount=*/10,
+                                                 /*nowNs=*/3'500 * kMs, kTimeoutNs);
+    CHECK_FALSE(decision.disconnect);
+    CHECK(decision.state.lastCountSeen == 10);
+    CHECK(decision.state.lastActivityNs == 1'000 * kMs);
+}
+
+TEST_CASE("Client liveness: silence past the timeout disconnects", "[client-liveness]")
+{
+    const ClientLivenessState prev{/*lastCountSeen=*/10, /*lastActivityNs=*/1'000 * kMs};
+    // Same count 3.001s later: strictly greater than the threshold -> disconnect.
+    const auto decision = EvaluateClientLiveness(prev, /*currentCount=*/10,
+                                                 /*nowNs=*/4'001 * kMs, kTimeoutNs);
+    CHECK(decision.disconnect);
+
+    // Exactly at the threshold is not "greater than", so it does not disconnect.
+    const auto atThreshold = EvaluateClientLiveness(prev, /*currentCount=*/10,
+                                                    /*nowNs=*/1'000 * kMs + kTimeoutNs, kTimeoutNs);
+    CHECK_FALSE(atThreshold.disconnect);
+}
+
+TEST_CASE("Client liveness: a zero activity clock never disconnects", "[client-liveness]")
+{
+    const ClientLivenessState prev{/*lastCountSeen=*/0, /*lastActivityNs=*/0};
+    // No activity has ever been recorded (count still 0); even far past the
+    // timeout the client is never disconnected on this path.
+    const auto decision = EvaluateClientLiveness(prev, /*currentCount=*/0,
+                                                 /*nowNs=*/1'000'000 * kMs, kTimeoutNs);
+    CHECK_FALSE(decision.disconnect);
+    CHECK(decision.state.lastActivityNs == 0);
+}

--- a/tests/TestRuntimePlatform.cpp
+++ b/tests/TestRuntimePlatform.cpp
@@ -5,6 +5,16 @@
 #include "RuntimePlatform.h"
 #include "RuntimeSockets.h"
 
+#include <thread>
+
+#if defined(__APPLE__)
+#include <pthread/qos.h>
+#elif defined(__linux__)
+#include <cerrno>
+#include <pthread.h>
+#include <sched.h>
+#endif
+
 TEST_CASE("RuntimePlatform resolves config and state roots per platform", "[runtime-platform]")
 {
     oxrsys::runtime_platform::EnvironmentPaths environment = {};
@@ -63,4 +73,49 @@ TEST_CASE("RuntimeSockets invalid handle stays invalid after close", "[runtime-s
 
     oxrsys::runtime_socket::Close(socket);
     CHECK(!oxrsys::runtime_socket::IsValid(socket));
+}
+
+TEST_CASE("SetCurrentThreadTimeSensitive raises the calling thread's priority",
+          "[runtime-platform]")
+{
+    // Catch2 assertions are not safe off the test thread; the worker records
+    // what it saw and the checks run after the join.
+    bool queried = false;
+    bool stateOk = false;
+    std::thread worker([&] {
+        oxrsys::runtime_platform::SetCurrentThreadTimeSensitive();
+#if defined(__APPLE__)
+        qos_class_t qosClass = QOS_CLASS_UNSPECIFIED;
+        int relativePriority = 0;
+        queried = pthread_get_qos_class_np(pthread_self(), &qosClass, &relativePriority) == 0;
+        stateOk = qosClass == QOS_CLASS_USER_INTERACTIVE;
+#elif defined(_WIN32)
+        queried = true;
+        stateOk = GetThreadPriority(GetCurrentThread()) == THREAD_PRIORITY_HIGHEST;
+#elif defined(__linux__)
+        // Deterministic in both privilege worlds. With CAP_SYS_NICE the helper
+        // must have installed minimum-priority SCHED_FIFO; without it, retrying
+        // the same call must fail with exactly EPERM - proving the helper made
+        // the right request and privilege was the only blocker.
+        int policy = -1;
+        sched_param param = {};
+        queried = pthread_getschedparam(pthread_self(), &policy, &param) == 0;
+        if (policy == SCHED_FIFO)
+        {
+            stateOk = param.sched_priority == sched_get_priority_min(SCHED_FIFO);
+        }
+        else
+        {
+            sched_param retry = {};
+            retry.sched_priority = sched_get_priority_min(SCHED_FIFO);
+            stateOk = pthread_setschedparam(pthread_self(), SCHED_FIFO, &retry) == EPERM;
+        }
+#else
+        queried = true;
+        stateOk = true;
+#endif
+    });
+    worker.join();
+    CHECK(queried);
+    CHECK(stateOk);
 }

--- a/tests/TestRuntimeStatus.cpp
+++ b/tests/TestRuntimeStatus.cpp
@@ -31,6 +31,9 @@ std::filesystem::path RuntimeStatusPathForHome(const std::filesystem::path& home
 {
 #if defined(__APPLE__)
     return home / "Library/Application Support/OXRSys/runtime_status.json";
+#elif defined(_WIN32)
+    // The test points APPDATA at the temp home, so the status root is home/OXRSys.
+    return home / "OXRSys/runtime_status.json";
 #else
     if (const char* xdgStateHome = std::getenv("XDG_STATE_HOME");
         xdgStateHome != nullptr && xdgStateHome[0] != '\0')
@@ -51,7 +54,11 @@ TEST_CASE("RuntimeStatus writes streaming stats only while streaming", "[runtime
         ("openxr-runtime-status-test-" + std::to_string(suffix));
     std::filesystem::create_directories(home);
 
+#if defined(_WIN32)
+    _putenv_s("APPDATA", home.string().c_str());
+#else
     setenv("HOME", home.string().c_str(), 1);
+#endif
 
     RuntimeStatus::SetApplicationName("Status Test");
     RuntimeStatus::SetStreaming("usb_adb", "Quest 3");


### PR DESCRIPTION
Fixes to the streaming server's client lifecycle, plus the two small changes needed to make develop build and test cleanly on Windows so the whole branch is verifiable on all three platforms. One commit each so they can be reviewed (or dropped) independently.

### 1. Fix the MSVC build: std::popcount and the setenv test shim

`__builtin_popcountll` is a GCC/Clang builtin, so `StreamingServer.cpp` does not compile under MSVC; the codebase already requires C++20, so `std::popcount` from `<bit>` is a drop-in. The runtime-status test set `HOME` with POSIX `setenv`; on Windows the status path resolves from `APPDATA`, so the test points `APPDATA` at the temp directory with `_putenv_s` there instead.

### 2. Generate the runtime manifest beside the per-config binary

`file(GENERATE)` wrote `oxrsys-runtime.json` into the runtime binary dir with an absolute configure-time `library_path`, but the test environment points `XR_RUNTIME_JSON` at `TARGET_FILE_DIR`. The two only coincide for single-config generators; under Visual Studio the manifest never landed next to the DLL, so the loader-based test suites could never find the runtime. Generating straight into `TARGET_FILE_DIR` with a relative `library_path` puts the manifest beside the binary for every generator (the packaging scripts already rewrite `library_path` at install time).

### 3. Send discovery beacons to loopback for same-host clients

`BroadcastThread` only sends `ServerAnnounce` to 255.255.255.255. macOS does not loop a subnet broadcast back to local listeners, so a client running on the same machine (e.g. the simulator) never discovers the runtime. The beacon targets are now built from a small helper and sent to both the broadcast address and 127.0.0.1. (The helper takes `uint32_t` rather than `in_addr_t`, which winsock does not define.)

### 4. Disconnect silent clients and resume broadcasting

**Repro:** connect a client over WiFi, then kill it abruptly (crash, battery pull, walk out of range). A UDP client killed this way sends no `ServerDisconnect`, so the server stays in `Connected` forever: it never resumes broadcasting and no new client can ever connect until the server is restarted.

Fix: `SendFrame` now tracks tracking-packet activity, and after 3 s of silence while `Connected` treats the client as gone and goes through the normal `HandleClientDisconnect` path, which resumes broadcasting. The decision logic (a packet-count advance resets the activity clock; silence past the timeout disconnects; a zero activity clock never disconnects) lives in a pure `EvaluateClientLiveness` helper in the new `ClientLiveness.h`, with four unit tests in `tests/TestClientLiveness.cpp` covering the edges.

One scoping note: liveness is only evaluated from `SendFrame`, i.e. while the app is still submitting frames. If the app stops rendering entirely the watchdog does not run — that path is unchanged from today.

### 5. Raise encode/send threads to a time-sensitive priority

The per-frame encode and video-send threads run at default priority, so scheduler wakeup jitter feeds straight into frame delivery under load. Both threads now raise themselves to a time-sensitive class through a new `runtime_platform::SetCurrentThreadTimeSensitive()` helper (keeping OS calls out of the streaming code, alongside the existing platform utilities): `QOS_CLASS_USER_INTERACTIVE` on Apple platforms (observed to trim the p95 encode-callback tail during latency tuning; on Apple Silicon the QoS class also keeps these threads on performance cores), `THREAD_PRIORITY_HIGHEST` on Windows, and best-effort `SCHED_FIFO` on Linux (needs `CAP_SYS_NICE`; unprivileged processes silently keep `SCHED_OTHER`). The threads spend their lives blocked on condition variables, so this changes when they wake, not how much CPU they take.

A runtime-platform test verifies the thread state actually changes: exact read-back assertions on Apple (`QOS_CLASS_USER_INTERACTIVE`) and Windows (`THREAD_PRIORITY_HIGHEST`); on Linux either minimum-priority `SCHED_FIFO` took effect (privileged) or retrying the identical request fails with exactly `EPERM`, proving the helper made the right request and privilege was the only blocker.

### 6. Close a lost-wakeup race in the streaming server shutdown

`Stop()` stores `running_ = false` and notifies `videoSendCv_` without holding `videoSendMutex_`. If the notify lands between `VideoSendThread`'s predicate check and its wait, the wakeup is lost and the video-send join blocks forever. We caught this as an intermittent 120 s timeout of the ctest api suite while validating this branch on CI runners (every session fixture cycles a full server start/stop, so one run gets dozens of chances). `StreamingFrameQueue::Stop` already orders its stop flag with the queue lock for exactly this reason; `Stop()` now does the same before notifying.

### Testing

- Full `ctest` suite passes on macOS locally and on GitHub Actions runners for **all three platforms** (macOS, Linux, Windows) with a 3-platform build+test workflow on my fork — happy to contribute the workflow itself as a follow-up PR if you want CI on this repo.
- The Linux scheduling test was additionally run with `CAP_SYS_NICE` granted, confirming the privileged `SCHED_FIFO` path takes effect; without the capability the exact-`EPERM` assertion covers the unprivileged path.
- Each commit builds and passes standalone, so any of them can be dropped independently.
