### PR TITLE
Fix Quest controller input and reconnect crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ This file tracks user-facing, integration-facing, and runtime-relevant changes f
 
 ### Fixed
 
+- Fixed controller interaction-profile reporting so standard OpenXR apps (e.g. Unity with the Oculus Touch controller profile) receive controller input from Meta Quest / PICO headsets. `xrGetCurrentInteractionProfile` now returns the most-specific profile from the runtime's compatibility list that the application actually suggested bindings for (per the OpenXR spec), instead of a device-specific profile the app never bound — the latter made clients treat the controllers as absent even though input was already being routed. Falls back to `XR_NULL_PATH` when the app bound none.
 - Contained decode-error corruption on the Apple streaming clients: after a decode failure the decoder drops inter frames and re-requests a keyframe until an IRAP (H.265) or IDR (H.264) arrives, so packet loss shows a brief clean freeze instead of propagating green/blocky corruption.
 - Fixed a potential visionOS black screen when the server streams 8-bit H.265 while the client requests a 10-bit decode surface, by falling back to an 8-bit output surface when 10-bit session creation is rejected; the renderer already selects its color conversion from the buffer's actual pixel format.
 - Fixed SwiftUI Home USB ADB readiness oscillation by moving USB refresh/setup off the view update path, ignoring stale ADB results after source or device changes, preserving verified reverse ports across transient mapping-read failures, and running persisted USB startup reverse setup only once.

--- a/clients/android-vr/app/src/main/cpp/XrApp.cpp
+++ b/clients/android-vr/app/src/main/cpp/XrApp.cpp
@@ -2593,15 +2593,13 @@ void XrApp::ConfigureServerConnection(const protocol::ServerAnnounce& server,
     foveationEdgeRatioY_ = std::max(server.foveationEdgeRatioY, 1.0f);
     const bool clientFoveationOverride =
         (server.serverFeatures & protocol::SERVER_FEATURE_CLIENT_FOVEATION) != 0;
-    if (clientFoveationOverride)
-    {
-        ApplyClientFoveationPreset(server.clientFoveationPreset);
-    }
-    else
-    {
-        clientFoveationPreset_ = protocol::ClientFoveationPreset::Off;
-        ShutdownFoveation();
-    }
+    // This runs on the discovery thread. The FB foveation functions touch swapchains_/session_,
+    // which are owned by the render thread — calling them here races the render thread's session
+    // teardown on reconnect and crashes (SIGSEGV in ShutdownFoveation). Defer to RunFrame().
+    const protocol::ClientFoveationPreset requestedFoveationPreset =
+        clientFoveationOverride ? server.clientFoveationPreset
+                                : protocol::ClientFoveationPreset::Off;
+    pendingFoveationPreset_.store(static_cast<int>(requestedFoveationPreset));
 
     if (server.refreshRateHz > 0)
     {
@@ -3577,6 +3575,16 @@ void XrApp::RunFrame()
 
     RetryUsbAdbTransportIfNeeded();
     ApplyCompletedStreamConfigUpdate();
+
+    // Apply any foveation preset requested by the server (deferred here from the discovery thread,
+    // where touching swapchains_/session_ would race this thread's session lifecycle).
+    const int pendingFoveation = pendingFoveationPreset_.exchange(-1);
+    if (pendingFoveation >= 0 && pendingFoveation != appliedFoveationPreset_)
+    {
+        ApplyClientFoveationPreset(
+            static_cast<protocol::ClientFoveationPreset>(pendingFoveation));
+        appliedFoveationPreset_ = pendingFoveation;
+    }
 
     if (connectionState_.load() == ConnectionState::Connected &&
         !hasVideoTexture_ &&
@@ -5104,6 +5112,19 @@ protocol::TrackingPacket XrApp::BuildTrackingPacket(XrTime predictedDisplayTime)
             }
             if (controllerActive || aimActive)
             {
+                // Send the aim (pointer) pose separately from grip so the server can report
+                // /input/aim/pose correctly. Prefer the real aim pose; fall back to grip.
+                const XrPosef& aimSrc = aimActive ? aimLoc.pose : loc.pose;
+                float* apos = (hand == 0) ? packet.leftControllerAimPos : packet.rightControllerAimPos;
+                float* arot = (hand == 0) ? packet.leftControllerAimRot : packet.rightControllerAimRot;
+                apos[0] = aimSrc.position.x;
+                apos[1] = aimSrc.position.y;
+                apos[2] = aimSrc.position.z;
+                arot[0] = aimSrc.orientation.x;
+                arot[1] = aimSrc.orientation.y;
+                arot[2] = aimSrc.orientation.z;
+                arot[3] = aimSrc.orientation.w;
+
                 shellControllers_[hand].active = true;
                 shellControllers_[hand].aimActive = aimActive;
                 shellControllers_[hand].gripPose = controllerActive ? loc.pose : aimLoc.pose;
@@ -5134,6 +5155,21 @@ protocol::TrackingPacket XrApp::BuildTrackingPacket(XrTime predictedDisplayTime)
     readFloatAction(gripAction_, handPaths_[1], &packet.rightGrip);
     shellControllers_[0].triggerValue = packet.leftTrigger;
     shellControllers_[1].triggerValue = packet.rightTrigger;
+
+    // Diagnostics: what we actually put on the wire for the left hand — grip-pose quat vs
+    // head/view quat (both in appSpace_) and the grip/trigger values. Compare against the
+    // runtime's "quat head=... Lctrl=..." log to isolate the 90° controller tilt and grip flow.
+    static uint32_t sendDiagCounter = 0;
+    if (++sendDiagCounter % 270 == 1)
+    {
+        LOGI("SendDiag L: ctrlRot=(x%.3f y%.3f z%.3f w%.3f) headRot=(x%.3f y%.3f z%.3f w%.3f) "
+             "grip=%.2f trig=%.2f",
+             packet.leftControllerRot[0], packet.leftControllerRot[1],
+             packet.leftControllerRot[2], packet.leftControllerRot[3],
+             packet.headOrientation[0], packet.headOrientation[1],
+             packet.headOrientation[2], packet.headOrientation[3],
+             packet.leftGrip, packet.leftTrigger);
+    }
 
     // Thumbsticks
     readVector2Action(thumbstickAction_, handPaths_[0],
@@ -5255,6 +5291,7 @@ void XrApp::HandleSessionStateChange(XrSessionState newState)
         SetShellPassthroughActive(false);
         ShutdownHandTracking();
         ShutdownFoveation();
+        appliedFoveationPreset_ = -1;  // fresh session must re-apply foveation
         xrEndSession(session_);
         sessionRunning_ = false;
         LOGI("Session STOPPING -> ended");

--- a/clients/android-vr/app/src/main/cpp/XrApp.h
+++ b/clients/android-vr/app/src/main/cpp/XrApp.h
@@ -297,6 +297,17 @@ private:
     uint32_t clientRefreshRateHz_ = 90;
     protocol::ClientFoveationPreset clientFoveationPreset_ =
         protocol::ClientFoveationPreset::Off;
+    // Foveation preset requested by the server, applied on the render thread in RunFrame().
+    // The FB foveation functions touch swapchains_/session_ and MUST NOT run on the discovery
+    // thread — doing so races the render thread's session teardown on reconnect and crashes
+    // (SIGSEGV in ShutdownFoveation). -1 means nothing pending.
+    std::atomic<int> pendingFoveationPreset_{-1};
+    // The foveation preset currently applied to the live swapchains (-1 = none applied yet).
+    // Re-applying the same preset tears down a live foveation profile and rebuilds it every
+    // reconnect; the Meta driver faults destroying a profile still bound to valid swapchains, so
+    // we skip the churn unless the preset actually changed. Reset to -1 when the session stops so
+    // a fresh session re-applies. Touched only on the render thread.
+    int appliedFoveationPreset_ = -1;
     protocol::ClientReprojectionMode clientReprojectionMode_ =
         protocol::ClientReprojectionMode::Pose;
     bool serverFoveatedEncodingEnabled_ = false;

--- a/clients/shared/OXRSysStreaming/Sources/OXRSysStreaming/Protocol.swift
+++ b/clients/shared/OXRSysStreaming/Sources/OXRSysStreaming/Protocol.swift
@@ -347,6 +347,14 @@ public struct TrackingPacket: Sendable {
     public var leftHandJoints: HandJointData = HandJointData()
     public var rightHandJoints: HandJointData = HandJointData()
 
+    // Aim (pointer) pose — must stay byte-for-byte in sync with the C++ Protocol.h struct
+    // (the packet is sent as a raw struct copy). Distinct from the grip pose; defaults to
+    // identity for clients that don't yet populate it.
+    public var leftControllerAimPos: (Float, Float, Float) = (0, 0, 0)
+    public var leftControllerAimRot: (Float, Float, Float, Float) = (0, 0, 0, 1)
+    public var rightControllerAimPos: (Float, Float, Float) = (0, 0, 0)
+    public var rightControllerAimRot: (Float, Float, Float, Float) = (0, 0, 0, 1)
+
     public init() {}
 }
 

--- a/common/protocol/include/oxrsys/protocol/Protocol.h
+++ b/common/protocol/include/oxrsys/protocol/Protocol.h
@@ -321,6 +321,15 @@ struct TrackingPacket
     // Optional hand tracking payload per joint: x, y, z, radius
     float leftHandJoints[HAND_JOINT_COUNT][4];
     float rightHandJoints[HAND_JOINT_COUNT][4];
+
+    // Aim (pointer) pose — distinct from the grip pose above. OpenXR defines /input/grip/pose
+    // and /input/aim/pose with different orientations (~45-60° apart on Touch); games place the
+    // controller ray/model from the aim pose. Falls back to the grip pose when aim is unavailable.
+    // Appended at the end so the wire layout stays compatible with the Swift client's raw struct.
+    float leftControllerAimPos[3];
+    float leftControllerAimRot[4];
+    float rightControllerAimPos[3];
+    float rightControllerAimRot[4];
 };
 
 enum ButtonFlags : uint32_t

--- a/runtime/src/EntryPoint.cpp
+++ b/runtime/src/EntryPoint.cpp
@@ -28,6 +28,7 @@
 #include <exception>
 #include <memory>
 #include <vector>
+#include <array>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -82,6 +83,11 @@ struct SuggestedBinding
 };
 static std::unordered_map<uint64_t, std::vector<SuggestedBinding>> gSuggestedBindings;
 static bool gActionSetsAttached = false;
+// Last interaction profile we reported to the app per session, indexed [left, right]. Used to
+// detect when the current profile changes (e.g. streaming controllers become active mid-session)
+// so we can emit XrEventDataInteractionProfileChanged — without it the app queries
+// xrGetCurrentInteractionProfile once at startup and never learns the controllers appeared.
+static std::unordered_map<uint64_t, std::array<std::string, 2>> gReportedInteractionProfiles;
 static std::vector<uint64_t> gAttachedActionSetHandles;
 static std::vector<std::unique_ptr<DebugUtilsMessengerState>> gDebugUtilsMessengers;
 
@@ -152,6 +158,7 @@ static XrResult CleanupRuntimeState()
     gActions.clear();
     gActionSets.clear();
     gSuggestedBindings.clear();
+    gReportedInteractionProfiles.clear();
     gActionSetsAttached = false;
     gAttachedActionSetHandles.clear();
     gDebugUtilsMessengers.clear();
@@ -993,6 +1000,7 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrDestroySession(XrSession session)
     gHandTrackers.clear();
     gActionSetsAttached = false;
     gAttachedActionSetHandles.clear();
+    gReportedInteractionProfiles.clear();
     gSession.reset();
     return XR_SUCCESS;
 }
@@ -2268,18 +2276,26 @@ static void AccumulateBindingState(const InputManager& inputManager, const Sugge
 static std::string SelectCurrentInteractionProfileForInstance(
     const Instance* instance, const InputManager& inputManager, InputManager::Hand hand)
 {
-    for (const std::string& profilePath : inputManager.GetCurrentInteractionProfileCandidates(hand))
+    // Per the OpenXR spec, xrGetCurrentInteractionProfile must return a profile the application
+    // has actually suggested bindings for, or XR_NULL_PATH — never an arbitrary runtime-picked
+    // one. GetActiveInteractionProfiles gives the runtime's compatibility list most-specific
+    // first (e.g. Quest 2: meta/touch_controller_quest_2 → oculus/touch_controller →
+    // khr/simple_controller); return the first entry the app bound. Reporting an unbound
+    // device-specific profile (as before) makes clients like Unity — which bind the standard
+    // Oculus Touch profile — treat the controllers as absent even though OxrSyncActions is
+    // already routing their input through this same compatibility list.
+    for (const std::string& profilePath : inputManager.GetActiveInteractionProfiles(hand))
     {
-        if (!profilePath.empty() && IsKnownInteractionProfilePath(instance, profilePath))
+        if (profilePath.empty() || !IsKnownInteractionProfilePath(instance, profilePath))
+        {
+            continue;
+        }
+        XrPath path = XR_NULL_PATH;
+        Runtime::Get().StringToPath(profilePath.c_str(), &path);
+        if (gSuggestedBindings.find(static_cast<uint64_t>(path)) != gSuggestedBindings.end())
         {
             return profilePath;
         }
-    }
-
-    if (inputManager.IsControllerTrackingActive(hand) &&
-        IsKnownInteractionProfilePath(instance, "/interaction_profiles/oculus/touch_controller"))
-    {
-        return "/interaction_profiles/oculus/touch_controller";
     }
 
     return "";
@@ -2411,6 +2427,31 @@ static XRAPI_ATTR XrResult XRAPI_CALL OxrSyncActions(
             }
             action->ApplySyncState(subactionPath, aggregate, syncTime);
         }
+    }
+
+    // Detect a change in the current interaction profile (e.g. streaming controllers just became
+    // active) and notify the app so it re-queries xrGetCurrentInteractionProfile. Without this the
+    // app caches the startup value (XR_NULL_PATH before any client connects) and never binds the
+    // controllers that appear later.
+    std::array<std::string, 2> current = {
+        SelectCurrentInteractionProfileForInstance(
+            sess->GetInstance(), inputManager, InputManager::Hand::Left),
+        SelectCurrentInteractionProfileForInstance(
+            sess->GetInstance(), inputManager, InputManager::Hand::Right)};
+    std::array<std::string, 2>& reported =
+        gReportedInteractionProfiles[reinterpret_cast<uint64_t>(session)];
+    if (current != reported)
+    {
+        reported = current;
+        XrEventDataBuffer event{};
+        auto* profileChanged =
+            reinterpret_cast<XrEventDataInteractionProfileChanged*>(&event);
+        profileChanged->type = XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED;
+        profileChanged->next = nullptr;
+        profileChanged->session = session;
+        sess->GetInstance()->PushEvent(event);
+        spdlog::info("OXRSys: Interaction profile changed (left='{}' right='{}')",
+                      current[0], current[1]);
     }
 
     return XR_SUCCESS;

--- a/runtime/src/InputManager.cpp
+++ b/runtime/src/InputManager.cpp
@@ -254,6 +254,13 @@ void InputManager::UpdateFromStreaming()
                                        packet.leftControllerRot[0],
                                        packet.leftControllerRot[1],
                                        packet.leftControllerRot[2]);
+        leftControllerAimPos_ = glm::vec3(packet.leftControllerAimPos[0],
+                                          packet.leftControllerAimPos[1],
+                                          packet.leftControllerAimPos[2]);
+        leftControllerAimRot_ = glm::quat(packet.leftControllerAimRot[3],
+                                          packet.leftControllerAimRot[0],
+                                          packet.leftControllerAimRot[1],
+                                          packet.leftControllerAimRot[2]);
     }
     if (rightControllerActive)
     {
@@ -264,6 +271,13 @@ void InputManager::UpdateFromStreaming()
                                         packet.rightControllerRot[0],
                                         packet.rightControllerRot[1],
                                         packet.rightControllerRot[2]);
+        rightControllerAimPos_ = glm::vec3(packet.rightControllerAimPos[0],
+                                           packet.rightControllerAimPos[1],
+                                           packet.rightControllerAimPos[2]);
+        rightControllerAimRot_ = glm::quat(packet.rightControllerAimRot[3],
+                                           packet.rightControllerAimRot[0],
+                                           packet.rightControllerAimRot[1],
+                                           packet.rightControllerAimRot[2]);
     }
 
     // Apply button/trigger states
@@ -316,11 +330,18 @@ void InputManager::UpdateFromStreaming()
     {
         spdlog::info("InputManager: streaming pos=({:.3f}, {:.3f}, {:.3f}) "
                       "L=({:.3f},{:.3f},{:.3f}) R=({:.3f},{:.3f},{:.3f}) "
-                      "trig={:.2f}/{:.2f} btn=0x{:x} flags=0x{:x}",
+                      "trig={:.2f}/{:.2f} grip={:.2f}/{:.2f} btn=0x{:x} flags=0x{:x}",
                       headPosition_.x, headPosition_.y, headPosition_.z,
                       leftControllerPos_.x, leftControllerPos_.y, leftControllerPos_.z,
                       rightControllerPos_.x, rightControllerPos_.y, rightControllerPos_.z,
-                      leftTrigger_, rightTrigger_, buttonState_, packet.trackingFlags);
+                      leftTrigger_, rightTrigger_, leftGripValue_, rightGripValue_,
+                      buttonState_, packet.trackingFlags);
+        // Quaternion diagnostics: head vs left controller (received, as glm w,x,y,z).
+        spdlog::info("InputManager: quat head=(x{:.3f} y{:.3f} z{:.3f} w{:.3f}) "
+                      "Lctrl=(x{:.3f} y{:.3f} z{:.3f} w{:.3f})",
+                      headQuat_.x, headQuat_.y, headQuat_.z, headQuat_.w,
+                      leftControllerRot_.x, leftControllerRot_.y,
+                      leftControllerRot_.z, leftControllerRot_.w);
     }
 
     // Log Quest IPD/FOV on first packet for debugging
@@ -438,6 +459,29 @@ XrPosef InputManager::GetControllerPose(Hand hand) const
     const glm::vec3& pos = (hand == Hand::Left) ? leftControllerPos_ : rightControllerPos_;
 
     glm::quat rot = (hand == Hand::Left) ? leftControllerRot_ : rightControllerRot_;
+
+    XrPosef pose{};
+    pose.orientation.x = rot.x;
+    pose.orientation.y = rot.y;
+    pose.orientation.z = rot.z;
+    pose.orientation.w = rot.w;
+    pose.position.x = pos.x;
+    pose.position.y = pos.y;
+    pose.position.z = pos.z;
+    return pose;
+}
+
+XrPosef InputManager::GetControllerAimPose(Hand hand) const
+{
+    const glm::vec3& pos = (hand == Hand::Left) ? leftControllerAimPos_ : rightControllerAimPos_;
+    glm::quat rot = (hand == Hand::Left) ? leftControllerAimRot_ : rightControllerAimRot_;
+
+    // Clients that don't populate the aim pose leave it identity/zero; fall back to the grip pose
+    // so /input/aim/pose is never worse than before this field existed.
+    if (rot.x == 0.0f && rot.y == 0.0f && rot.z == 0.0f && rot.w == 0.0f)
+    {
+        return GetControllerPose(hand);
+    }
 
     XrPosef pose{};
     pose.orientation.x = rot.x;
@@ -637,6 +681,18 @@ bool InputManager::GetButtonClick(Hand hand, const std::string& componentPath) c
     {
         return GetGrabValue(hand) > 0.5f;
     }
+    // The oculus/touch profile has no squeeze/click or trigger/click component — grip and trigger
+    // are analog-only (squeeze/value, trigger/value). Per the OpenXR spec, a boolean action bound
+    // to a float source must be thresholded by the runtime. Without this a boolean grip/trigger
+    // action bound to the value path always reads false (grip "never clicks").
+    if (componentPath == "squeeze/value")
+    {
+        return GetGrabValue(hand) > 0.5f;
+    }
+    if (componentPath == "trigger/value")
+    {
+        return GetTriggerValue(hand) > 0.5f;
+    }
     if (componentPath == "thumbstick/click")
     {
         uint32_t mask = (hand == Hand::Left)
@@ -833,7 +889,10 @@ XrPosef InputManager::GetPoseComponentForProfile(Hand hand, const std::string& c
         {
             return GetTrackedHandPose(hand, componentPath);
         }
-        return GetControllerPose(hand);
+        // grip and aim poses differ (~45-60° on Touch); return each from the client's distinct
+        // streamed pose so games placing content from aim/pose aren't tilted by the grip offset.
+        return (componentPath == "aim/pose") ? GetControllerAimPose(hand)
+                                             : GetControllerPose(hand);
     }
 
     if (componentPath == "pinch_ext/pose" || componentPath == "poke_ext/pose")

--- a/runtime/src/InputManager.h
+++ b/runtime/src/InputManager.h
@@ -50,6 +50,7 @@ public:
 
     // Controller poses (world space)
     XrPosef GetControllerPose(Hand hand) const;
+    XrPosef GetControllerAimPose(Hand hand) const;
 
     // Hand tracking joints (26 joints, world space relative to baseSpace)
     void GetHandJointLocations(Hand hand, XrHandJointLocationEXT* joints, uint32_t jointCount) const;
@@ -121,6 +122,9 @@ private:
     glm::quat headQuat_ = glm::quat(1.0f, 0.0f, 0.0f, 0.0f); // w,x,y,z
     glm::quat leftControllerRot_ = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
     glm::quat rightControllerRot_ = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+    // Aim (pointer) pose — distinct from grip; zero quaternion means "not supplied" (fall back).
+    glm::quat leftControllerAimRot_ = glm::quat(0.0f, 0.0f, 0.0f, 0.0f);
+    glm::quat rightControllerAimRot_ = glm::quat(0.0f, 0.0f, 0.0f, 0.0f);
     glm::vec3 headPosition_ = {0.0f, 1.6f, 0.0f};
 
     // Streaming controller state
@@ -138,6 +142,8 @@ private:
     // Controller positions (world space offsets)
     glm::vec3 leftControllerPos_ = {-0.2f, 1.3f, -0.4f};
     glm::vec3 rightControllerPos_ = {0.2f, 1.3f, -0.4f};
+    glm::vec3 leftControllerAimPos_ = {-0.2f, 1.3f, -0.4f};
+    glm::vec3 rightControllerAimPos_ = {0.2f, 1.3f, -0.4f};
 
     // Button states
     bool leftGrab_ = false;

--- a/runtime/src/TrackingReceiver.cpp
+++ b/runtime/src/TrackingReceiver.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstring>
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
@@ -204,6 +205,14 @@ void TrackingReceiver::Stop()
     spdlog::info("TrackingReceiver: Stopped ({} packets received)", packetCount_.load());
 }
 
+// Minimum acceptable tracking packet: everything up to (but not including) the aim-pose fields,
+// which were appended later. Older clients — and the visionOS client until it's rebuilt — send
+// exactly this many bytes. We zero-init the packet so any fields the client didn't send (e.g. the
+// aim pose) stay zero, and the runtime falls back to the grip pose for aim/pose. This keeps the
+// protocol backward-compatible instead of dropping every shorter packet as "no tracking".
+static constexpr size_t kMinTrackingPacketSize =
+    offsetof(oxr::protocol::TrackingPacket, leftControllerAimPos);
+
 void TrackingReceiver::ReceiveThread()
 {
     uint8_t buffer[sizeof(oxr::protocol::TrackingPacket)];
@@ -213,26 +222,27 @@ void TrackingReceiver::ReceiveThread()
         oxrsys::runtime_socket::SetReceiveTimeout(socket_, 0, 5000);
 
         int received = oxrsys::runtime_socket::Receive(socket_, buffer, sizeof(buffer), 0);
-        if (received < static_cast<int>(sizeof(oxr::protocol::TrackingPacket)))
+        if (received < static_cast<int>(kMinTrackingPacketSize))
         {
             continue;
         }
 
         oxr::protocol::TrackingPacket packet = {};
-        memcpy(&packet, buffer, sizeof(packet));
+        size_t copyBytes = std::min(static_cast<size_t>(received), sizeof(packet));
+        memcpy(&packet, buffer, copyBytes);
         StorePacket(packet, SteadyClockNowNs());
     }
 }
 
 void TrackingReceiver::InjectPacket(const uint8_t* data, size_t size)
 {
-    if (size < sizeof(oxr::protocol::TrackingPacket))
+    if (size < kMinTrackingPacketSize)
     {
         return;
     }
 
     oxr::protocol::TrackingPacket packet = {};
-    memcpy(&packet, data, sizeof(packet));
+    memcpy(&packet, data, std::min(size, sizeof(packet)));
     StorePacket(packet, SteadyClockNowNs());
 }
 

--- a/tests/TestProtocolLayout.cpp
+++ b/tests/TestProtocolLayout.cpp
@@ -48,11 +48,16 @@ TEST_CASE("C++ protocol layouts match the documented wire format", "[protocol]")
     STATIC_REQUIRE(SERVER_FEATURE_STREAM_RECONFIGURE == 0x00000010);
     STATIC_REQUIRE(CLIENT_CAPABILITY_STREAM_RECONFIGURE == 0x00000010);
 
-    STATIC_REQUIRE(sizeof(TrackingPacket) == 1008);
+    STATIC_REQUIRE(sizeof(TrackingPacket) == 1064);
     STATIC_REQUIRE(offsetof(TrackingPacket, headLinearVelocity) == 152);
     STATIC_REQUIRE(offsetof(TrackingPacket, headAngularVelocity) == 164);
     STATIC_REQUIRE(offsetof(TrackingPacket, leftHandJoints) == 176);
     STATIC_REQUIRE(offsetof(TrackingPacket, rightHandJoints) == 592);
+    // Aim pose appended after the hand-joint payload (must match Swift Protocol.swift layout).
+    STATIC_REQUIRE(offsetof(TrackingPacket, leftControllerAimPos) == 1008);
+    STATIC_REQUIRE(offsetof(TrackingPacket, leftControllerAimRot) == 1020);
+    STATIC_REQUIRE(offsetof(TrackingPacket, rightControllerAimPos) == 1036);
+    STATIC_REQUIRE(offsetof(TrackingPacket, rightControllerAimRot) == 1048);
     STATIC_REQUIRE(TRACKING_FLAG_LEFT_CONTROLLER_ACTIVE == 0x0004);
     STATIC_REQUIRE(TRACKING_FLAG_RIGHT_CONTROLLER_ACTIVE == 0x0008);
 }


### PR DESCRIPTION
Related to issue [https://github.com/demonixis/oxrsys/issues/6](https://github.com/demonixis/oxrsys/issues/6)


Controllers streamed from a Quest client were unusable by OpenXR apps that were using meta/oculus input profiles: they never appeared in Unity at all, the models rendered visibly tilted, grip never registered a press, and taking the headset off and on crashed the client.

Interaction profiles
- xrGetCurrentInteractionProfile reported a device-specific profile the app had never suggested bindings for (e.g. meta/touch_controller_quest_2). The spec requires a profile the app actually bound, or XR_NULL_PATH, so report the first entry of the compatibility list the app suggested bindings for. Input was already routed through that same list.
- Emit XrEventDataInteractionProfileChanged, which was never sent at all. An app queries the current profile once at startup - before any headset has connected - caches "no controller" and never asks again, so controllers that became active later stayed invisible. The profile is now re-resolved each xrSyncActions and the event pushed when it changes.

Poses
- Serve /input/aim/pose from a distinct streamed aim pose instead of reusing the grip pose. Games place the controller model and ray from aim, which sits 45-60 degrees away from grip on Touch, which is what made controllers look rotated. The Quest client already computed the aim pose and now sends it.

Buttons
- Threshold squeeze/value and trigger/value for boolean actions. The oculus/touch profile has no squeeze/click - grip is analog-only - so a boolean grip action bound to the value path always read false and grip never clicked.

Protocol
- The aim pose fields are appended to TrackingPacket, and the receiver accepts packets down to the pre-aim size and zero-fills the rest, so existing clients keep working and a missing aim pose falls back to the grip pose. Protocol.swift is updated in step because the packet is sent as a raw struct copy, and the layout test pins the new size and field offsets.

Quest client
- Fix a SIGSEGV on reconnect. The client applied the server's foveation preset on the discovery thread, racing the render thread's session teardown inside the Meta VR driver. Applying it is deferred to RunFrame and made idempotent, so an unchanged preset no longer tears down and rebuilds a live foveation profile.

### Testing

Meta Quest 2 hardware streaming from a Mac M5 Pro, same unity project settings as on a windows machine.